### PR TITLE
Add public link to podcast cover setter.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -457,12 +457,18 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             'title' => $this->getMeta('title'),
             'description' => $this->getMeta('description'),
             'status' => $this->getStatus(),
-            'editlink' => array(
+            'editlink' => [
                 'display' => 'icon',
                 'value' => 'script',
                 'title' => 'Edit Podcast',
                 'url' => CoreUtils::makeURL('Podcast', 'editPodcast', array('podcastid' => $this->getID()))
-            )
+            ],
+            'setcoverlink' => [
+                'display' => 'icon',
+                'value' => 'script',
+                'title' => 'Set Cover',
+                'url' => CoreUtils::makeURL('Podcast', 'setCover', array('podcastid' => $this->getID()))
+            ]
         );
 
         if ($full) {


### PR DESCRIPTION
Podcast cover setter is STILL under development, but this has been
requested by Head of News, and will likely be needed for CIN.

Use at your own risk.
