### PR TITLE
Stop timelord from autorefreshing

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -392,7 +392,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                     'title' => Config::$short_name . ' Jukebox',
                     'desc' => 'Non-stop Music',
                     'photo' => Config::$default_show_uri,
-                    'end_time' => $next->getStartTime()
+                    'end_time' => $next ? $next->getStartTime() : 'The End of Time'
                 ]
             ];
         } else {


### PR DESCRIPTION
Turns out that if there's no other show scheduled, there is no next show
..which causes the ajax request to 'fail', which refreshes the timelord page approx 3 times/sec, which causes jukebox to overheat
