### PR TITLE
only check response["next"] if it exists

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -453,7 +453,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             }
         }
 
-        if (sizeof($response['next']) === 1) {
+        if (isset($response['next']) && sizeof($response['next']) === 1) {
             $response['next'] = $response['next'][0];
         }
 


### PR DESCRIPTION
fixes [error] 95114#0: *288605 FastCGI sent in stderr: "PHP message: Notice: Undefined index: next in /usr/local/www/myradio-dev/src/Classes/ServiceAPI/MyRadio_Timeslot.php on line 456" while reading response header from upstream
