### PR TITLE
Setting a non-default authenticator now unrequires pw change

### DIFF
--- a/src/Controllers/MyRadio/chooseAuth.php
+++ b/src/Controllers/MyRadio/chooseAuth.php
@@ -19,9 +19,10 @@ if (!in_array($_REQUEST['authenticator'], Config::$authenticators)) {
 //Set the authenticator
 MyRadio_User::getInstance()->setAuthProvider($_REQUEST['authenticator']);
 
-//If it's not the Default authenticator, delete the password
+//If it's not the Default authenticator, delete the password and make require password change false
 if ($_REQUEST['authenticator'] !== 'MyRadioDefaultAuthenticator') {
     (new MyRadioDefaultAuthenticator())->removePassword($_SESSION['memberid']);
+    MyRadio_User::getInstance()->setRequirePasswordChange(false);
 }
 
 //Remove the lock on Session access


### PR DESCRIPTION
This is probably wrong.
![image](https://cloud.githubusercontent.com/assets/3065381/2757197/2048cb36-c982-11e3-95f1-876184c75f94.png)
