### PR TITLE
Put MP3 headers back into ffmpeg encodes

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -624,7 +624,7 @@ class MyRadio_Track extends ServiceAPI
         $tmpfile = Config::$audio_upload_tmp_dir . '/' . $tmpid;
         $dbfile = $ainfo['album']->getFolder() . '/' . $track->getID();
 
-        shell_exec("nice -n 15 ffmpeg -i '$tmpfile' -ab 192k -f mp3 - >'{$dbfile}.mp3'");
+        shell_exec("nice -n 15 ffmpeg -i '$tmpfile' -ab 192k -f mp3 '{$dbfile}.mp3'");
         shell_exec("nice -n 15 ffmpeg -i '$tmpfile' -acodec libvorbis -ab 192k '{$dbfile}.ogg'");
         rename($tmpfile, $dbfile . '.mp3.orig');
 


### PR DESCRIPTION
Please verify that track uploads still work after by uploading a track and playing it on BAPS.

Testing playback on Show Planner is NOT sufficient!
