### PR TITLE
Fixes undefined variable: $time

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_MetadataSubject.php
+++ b/src/Classes/ServiceAPI/MyRadio_MetadataSubject.php
@@ -179,8 +179,8 @@ trait MyRadio_MetadataSubject
             $key,
             $this->getID(),
             MyRadio_User::getCurrentOrSystemUser()->getID(),
-            CoreUtils::getTimestamp($time),
-            $effective_to == null ? null : CoreUtils::getTimestamp($effective_to)
+            CoreUtils::getTimestamp($from),
+            $to == null ? null : CoreUtils::getTimestamp($to)
         ];
 
         $param_counter = 6;


### PR DESCRIPTION
Turns out actually using the parameters you provide helps
