### PR TITLE
Persist a post login redirect through login failiure

### DIFF
--- a/src/Controllers/MyRadio/login.php
+++ b/src/Controllers/MyRadio/login.php
@@ -44,7 +44,7 @@ $form = (
         'next',
         MyRadioFormField::TYPE_HIDDEN,
         [
-            'value' => isset($_REQUEST['next']) ? $_REQUEST['next'] : Config::$base_url
+            'value' => isset($_REQUEST['next']) ? $_REQUEST['next'] : ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['myradio_login-next']) ? $_POST['myradio_login-next'] : Config::$base_url)
         ]
     )
 )->setTemplate('MyRadio/login.twig');


### PR DESCRIPTION
This is done by populating the hidden 'next' field with its own value on post if there is not a next url parameter. Closes #141
