### PR TITLE
Fix recursive impersonations

### DIFF
--- a/src/Controllers/MyRadio/impersonate.php
+++ b/src/Controllers/MyRadio/impersonate.php
@@ -24,7 +24,10 @@ if (isset($_REQUEST['memberid'])) {
     ) {
         require_once 'Controllers/Errors/403.php';
     } else {
-        $_SESSION['myradio-impersonating'] = $_SESSION;
+        // Yes, this temporary variable is necessary, otherwise recursion happens.
+        // I don't even.
+        $old_sess = $_SESSION;
+        $_SESSION['myradio-impersonating'] = $old_sess;
         $_SESSION['memberid'] = $impersonatee->getID();
         $ip_auth = Database::getInstance()->fetchColumn(
             'SELECT typeid FROM auth_subnet WHERE subnet >>= $1',
@@ -35,12 +38,7 @@ if (isset($_REQUEST['memberid'])) {
         $_SESSION['email'] = $impersonatee->getEmail();
         $_SESSION['auth_use_locked'] = false;
     }
-} else {
-    /**
-     * For some reason I sometimes have to unimpersonate 3 or more times before
-     * the impersonating key actually gets reset...
-     */
-    while (isset($_SESSION['myradio-impersonating'])) {
+} else if (isset($_SESSION['myradio-impersonating'])) {
         //Unimpersonate
         $impersonate = $_SESSION['myradio-impersonating'];
         $_SESSION = $impersonate;


### PR DESCRIPTION
There were some privacy concerns with being left logged in as the person you were impersonating

PHP, not even once.
Fixes #181
