### PR TITLE
error, but don't except on API error, and stop processing after error

### DIFF
--- a/src/PublicAPI/index.php
+++ b/src/PublicAPI/index.php
@@ -39,7 +39,8 @@ function api_error($code, $message = null, $previous = null)
         "message" => $message
     ]);
     //Log an API failure so it appears in the status graphs.
-    throw new MyRadioException('API Error: ' . $message . "\nSource: " . $_SERVER['REMOTE_ADDR'], $code, $previous);
+    trigger_error('API Error: [' . $code . '] ' . $message . "\nSource: " . $_SERVER['REMOTE_ADDR']);
+    exit;
 }
 
 /**


### PR DESCRIPTION
ensures data is clean, and errors are still logged in the system.

@Flump5281 happy for this not to be producing exceptions?
