### PR TITLE
Stop footer being fixed

### DIFF
--- a/src/Public/css/style.css
+++ b/src/Public/css/style.css
@@ -15,10 +15,6 @@ body {
 }
 
 .footer {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  min-height: 40px;
   padding: 8px 0;
   background-color: #f5f5f5;
 }


### PR DESCRIPTION
There is no need for the footer to be fixed:
- The main menu has enough height that it obscures part of it on circa 13" laptop screens (common size)
- It is not that important (unlike the navbar for example). If people need it, it is at the bottom.
