### PR TITLE
Auto-playlist and lookup improvements

### DIFF
--- a/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
+++ b/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
@@ -197,11 +197,24 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
                         'title' => $r['name'],
                         'artist' => $r['artist']['#text'],
                         'limit' => 1,
-                        'digitised' => true
+                        'digitised' => true,
+                        'precise' => true
                     ]
                 );
+                
+                if (empty($c)) {
+                    $c = MyRadio_Track::findByOptions(
+                        [
+                            'title' => $r['name'],
+                            'artist' => $r['artist']['#text'],
+                            'limit' => 1,
+                            'digitised' => true
+                        ]
+                    );
+                }
+                
                 if (!empty($c)) {
-                $keys[] = $c[0]->getID();
+                    $keys[] = $c[0]->getID();
                 }
             }
         }
@@ -252,9 +265,22 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
                     'title' => $r['name'],
                     'artist' => $r['artist']['name'],
                     'limit' => 1,
-                    'digitised' => true
+                    'digitised' => true,
+                    'precise' => true
                 ]
             );
+            
+            if (empty($c)) {
+                $c = MyRadio_Track::findByOptions(
+                    [
+                        'title' => $r['name'],
+                        'artist' => $r['artist']['#text'],
+                        'limit' => 1,
+                        'digitised' => true
+                    ]
+                );
+            }
+            
             if (!empty($c)) {
                 $playlist[] = $c[0];
             }
@@ -287,9 +313,22 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
                     'title' => $r['name'],
                     'artist' => $r['artist']['name'],
                     'limit' => 1,
-                    'digitised' => true
+                    'digitised' => true,
+                    'precise' => true
                 ]
             );
+            
+            if (empty($c)) {
+                $c = MyRadio_Track::findByOptions(
+                    [
+                        'title' => $r['name'],
+                        'artist' => $r['artist']['#text'],
+                        'limit' => 1,
+                        'digitised' => true
+                    ]
+                );
+            }
+            
             if (!empty($c)) {
                 $playlist[] = $c[0];
             }
@@ -322,9 +361,22 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
                     'title' => $r['name'],
                     'artist' => $r['artist']['name'],
                     'limit' => 1,
-                    'digitised' => true
+                    'digitised' => true,
+                    'precise' => true
                 ]
             );
+            
+            if (empty($c)) {
+                $c = MyRadio_Track::findByOptions(
+                    [
+                        'title' => $r['name'],
+                        'artist' => $r['artist']['#text'],
+                        'limit' => 1,
+                        'digitised' => true
+                    ]
+                );
+            }
+            
             if (!empty($c)) {
                 $playlist[] = $c[0];
             }

--- a/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
+++ b/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
@@ -92,7 +92,11 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             dlog('Found ' . sizeof($similar) . ' similar tracks for ' . $track->getID(), 4);
             //Add these to the playlist, along with the popular track
             $playlist[] = $track;
-            $playlist = array_merge($playlist, $similar);
+            for ($j = 0; $j < sizeof($similar); $j++)
+            {
+                $playlist[] = $similar[j];
+            }
+            //$playlist = array_merge($playlist, $similar);
         }
         //Actually update the playlist
         $pobj->setTracks(array_unique($playlist), $lockstr, null, MyRadio_User::getInstance(Config::$system_user));
@@ -135,7 +139,11 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             $similar = $track->getSimilar();
             dlog('Found ' . sizeof($similar) . ' similar tracks for ' . $track->getID(), 4);
             $playlist[] = $track;
-            $playlist = array_merge($playlist, $similar);
+            for ($j = 0; $j < sizeof($similar); $j++)
+            {
+                $playlist[] = $similar[j];
+            }
+            //$playlist = array_merge($playlist, $similar);
         }
 
         $pobj->setTracks(array_unique($playlist), $lockstr, null, MyRadio_User::getInstance(Config::$system_user));
@@ -199,7 +207,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
         }
         
         $playlist = [];
-        for ($i = 0; $i < 100; $i++) {
+        for ($i = 0; $i < sizeof($keys); $i++) {
             $lockstr = $pobj->acquireOrRenewLock($lockstr, MyRadio_User::getInstance(Config::$system_user));
             $key = $keys[$i];
             if (!$key) {
@@ -209,7 +217,11 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             $similar = $track->getSimilar();
             dlog('Found ' . sizeof($similar) . ' similar tracks for ' . $track->getID(), 4);
             $playlist[] = $track;
-            $playlist = array_merge($playlist, $similar);
+            for ($j = 0; $j < sizeof($similar); $j++)
+            {
+                $playlist[] = $similar[j];
+            }
+            //$playlist = array_merge($playlist, $similar);
         }
         
         $pobj->setTracks(array_unique($playlist), $lockstr, null, MyRadio_User::getInstance(Config::$system_user));

--- a/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
+++ b/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
@@ -94,7 +94,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             $playlist[] = $track;
             for ($j = 0; $j < sizeof($similar); $j++)
             {
-                $playlist[] = $similar[j];
+                $playlist[] = $similar[$j];
             }
             //$playlist = array_merge($playlist, $similar);
         }
@@ -141,7 +141,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             $playlist[] = $track;
             for ($j = 0; $j < sizeof($similar); $j++)
             {
-                $playlist[] = $similar[j];
+                $playlist[] = $similar[$j];
             }
             //$playlist = array_merge($playlist, $similar);
         }
@@ -220,19 +220,15 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
         }
         
         $playlist = [];
-        for ($i = 0; $i < sizeof($keys); $i++) {
+        foreach ($keys as $key) {
             $lockstr = $pobj->acquireOrRenewLock($lockstr, MyRadio_User::getInstance(Config::$system_user));
-            $key = $keys[$i];
-            if (!$key) {
-                break; //If there aren't that many, oh well.
-            }
             $track = MyRadio_Track::getInstance($key);
             $similar = $track->getSimilar();
             dlog('Found ' . sizeof($similar) . ' similar tracks for ' . $track->getID(), 4);
             $playlist[] = $track;
             for ($j = 0; $j < sizeof($similar); $j++)
             {
-                $playlist[] = $similar[j];
+                $playlist[] = $similar[$j];
             }
             //$playlist = array_merge($playlist, $similar);
         }

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -927,9 +927,22 @@ class MyRadio_Track extends ServiceAPI
                             'title' => $r['name'],
                             'artist' => $r['artist']['name'],
                             'limit' => 1,
-                            'digitised' => true
+                            'digitised' => true,
+                            'precise' => true
                         ]
                     );
+            
+                    if (empty($c)) {
+                        $c = self::findByOptions(
+                            [
+                                'title' => $r['name'],
+                                'artist' => $r['artist']['name'],
+                                'limit' => 1,
+                                'digitised' => true
+                            ]
+                        );
+                    }
+                    
                     if (!empty($c)) {
                         $this->lastfm_similar[] = $c[0]->getID();
                     }


### PR DESCRIPTION
array_merge can have some funny behaviour from what I have been reading. For instance if $track has key [0] and $similar allocates keys starting at [0], then it may overwrite the original track. This may fix that. If not, swapping the lines (as they were before) will return it to its original behaviour, albeit with the similar tracks appearing above the original track.

I also changed the 100 in my group chart thing to sizeof($keys), as this is a bit neater and more explicit.

If this does not fix the missing $track issue, then I will request a dlog to check what the array_unique is working with.