### PR TITLE
Add factories for show

### DIFF
--- a/schema/base.sql
+++ b/schema/base.sql
@@ -2084,7 +2084,7 @@ CREATE TABLE show_image_metadata (
     effective_from timestamp with time zone,
     effective_to timestamp with time zone,
     metadata_key_id integer NOT NULL,
-    metadata_value character varying(100) NOT NULL,
+    metadata_value character text NOT NULL,
     show_id integer,
     show_image_metadata_id integer NOT NULL
 );

--- a/src/Classes/APCProvider.php
+++ b/src/Classes/APCProvider.php
@@ -82,6 +82,23 @@ class APCProvider implements \MyRadio\Iface\CacheProvider
         return apc_fetch($this->getKeyPrefix().$key);
     }
 
+    public function getAll($prefix = '')
+    {
+        if (!$this->enable) {
+            return [];
+        }
+        
+        $prefix = preg_quote($this->getKeyPrefix() . $prefix);
+
+        $result = [];
+        $it = new \APCIterator('user', '/^' . $prefix . '/', APC_ITER_VALUE);
+        foreach ($it as $row) {
+            $result[] = $row['value'];
+        }
+
+        return $result;
+    }
+
     /**
      * Deletes a previously stored value from the APC User Object Cache
      *

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -234,6 +234,8 @@ class Database
      * json_decode *nearly* works in some cases, but this tends to be more reliable
      *
      * Based on http://stackoverflow.com/questions/3068683/convert-postgresql-array-to-php-array
+     *
+     * @deprecated Use json output from Postgres instead
      */
     public function decodeArray($text)
     {

--- a/src/Classes/ServiceAPI/ServiceAPI.php
+++ b/src/Classes/ServiceAPI/ServiceAPI.php
@@ -78,11 +78,17 @@ abstract class ServiceAPI implements IServiceAPI, MyRadio_DataSource
         $key = self::getCacheKey($itemid);
         $cache = self::$cache->get($key);
         if (!$cache) {
-            $cache = new $class($itemid);
+            $cache = $class::factory($itemid);
             self::$cache->set($key, $cache);
         }
 
         return $cache;
+    }
+
+    protected static function factory($itemid)
+    {
+        $class = get_called_class();
+        return new $class($itemid);
     }
 
     public function toDataSource($full = false)

--- a/src/Interfaces/CacheProvider.php
+++ b/src/Interfaces/CacheProvider.php
@@ -23,7 +23,7 @@ interface CacheProvider extends Singleton
      */
     public function get($key);
     /**
-     * Gets all cache entries starting with the given prefic
+     * Gets all cache entries starting with the given prefix
      * @return Array
      */
     public function getAll($prefix = '');

--- a/src/Interfaces/CacheProvider.php
+++ b/src/Interfaces/CacheProvider.php
@@ -23,6 +23,11 @@ interface CacheProvider extends Singleton
      */
     public function get($key);
     /**
+     * Gets all cache entries starting with the given prefic
+     * @return Array
+     */
+    public function getAll($prefix = '');
+    /**
      * Deletes a cache entry
      */
     public function delete($key);


### PR DESCRIPTION
Substantially improves startup time and database load for fetching all shows on an empty cache. Provides the ServiceAPI functionality to expand this further in future.

- Update image_metadata type to TEXT
- Deprecate Database::decodeArray
- Add default factory method to serviceapi
- Re-write show select query to support returning multiple rows
- Replace getAllShows iterator with single query
- Expand CacheProvider interface with getAll feature