### PR TITLE
Precise search for Similar Tracks

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -774,17 +774,17 @@ class MyRadio_Track extends ServiceAPI {
                     $c = self::findByOptions(['title' => $r['name'],
                                 'artist' => $r['artist']['name'],
                                 'limit' => 1,
-                                'digitised' => true
+                                'digitised' => true,
                                 'precise' => true]);
                     //Try to find a not-so-exact match
-                    if (!empty($c)) {
+                    if (empty($c)) {
                         $c = self::findByOptions(['title' => $r['name'],
                                 'artist' => $r['artist']['name'],
                                 'limit' => 1,
-                                'digitised' => true
+                                'digitised' => true,
                                 'precise' => false]);
                     }
-                    //Still nothing
+                    //If match found, add track to Similar list
                     if (!empty($c)) {
                         $this->lastfm_similar[] = $c[0]->getID();
                     }

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -770,10 +770,21 @@ class MyRadio_Track extends ServiceAPI {
             }
             foreach ($data['similartracks']['track'] as $r) {
                 if ($r['match'] >= 0.25) {
+                    //Try to find an exact match
                     $c = self::findByOptions(['title' => $r['name'],
                                 'artist' => $r['artist']['name'],
                                 'limit' => 1,
-                                'digitised' => true]);
+                                'digitised' => true
+                                'precise' => true]);
+                    //Try to find a not-so-exact match
+                    if (!empty($c)) {
+                        $c = self::findByOptions(['title' => $r['name'],
+                                'artist' => $r['artist']['name'],
+                                'limit' => 1,
+                                'digitised' => true
+                                'precise' => false]);
+                    }
+                    //Still nothing
                     if (!empty($c)) {
                         $this->lastfm_similar[] = $c[0]->getID();
                     }


### PR DESCRIPTION
Discovered issues with some of the selections of Similar Tracks in appropriate playlists (e.g. *Nirvana - Lithium (Live)* when *Nirvana - Lithium* is available). Copying - hopefully - for similar functionality as other library searches.