### PR TITLE
Support datasource responses with mixins

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_List.php
+++ b/src/Classes/ServiceAPI/MyRadio_List.php
@@ -314,7 +314,7 @@ class MyRadio_List extends ServiceAPI
     }
 
     /**
-     *
+     * Return all mailing lists
      * @return MyRadio_User[]
      */
     public static function getAllLists()

--- a/src/Classes/ServiceAPI/MyRadio_List.php
+++ b/src/Classes/ServiceAPI/MyRadio_List.php
@@ -313,6 +313,10 @@ class MyRadio_List extends ServiceAPI
         }
     }
 
+    /**
+     *
+     * @return MyRadio_User[]
+     */
     public static function getAllLists()
     {
         $r = self::$db->fetchColumn('SELECT listid FROM mail_list');


### PR DESCRIPTION
Some things, such as /api/v2/list/22/members, returns a set of dataSource'd objects from another class. Mixins are passed through correctly, but permissions were not properly verified.

This fixes that.