### PR TITLE
Some performance optimisations

### DIFF
--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -128,7 +128,7 @@ class Database
         $this->counter++;
 
         if (defined('DB_PROFILE')) {
-            echo (microtime(true) - $timer) + "s\n";
+            echo (microtime(true) - $timer) . "s\n";
         }
 
         return $result;

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -104,9 +104,10 @@ class Database
             }
         }
 
-        if (isset($_REQUEST['dbdbg']) && AuthUtils::hasPermission(AUTH_SHOWERRORS)) {
+        if (defined('DB_PROFILE')) {
             //Debug output
-            echo $sql . '&nbsp;' . print_r($params, true) . '<br>';
+            echo $sql . '&nbsp;' . print_r($params, true) . '...';
+            $timer = microtime(true);
         }
 
         if (empty($params)) {
@@ -125,6 +126,10 @@ class Database
             );
         }
         $this->counter++;
+
+        if (defined('DB_PROFILE')) {
+            echo (microtime(true) - $timer) + "s\n";
+        }
 
         return $result;
     }

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -106,7 +106,7 @@ class Database
 
         if (defined('DB_PROFILE')) {
             //Debug output
-            echo $sql . '&nbsp;' . print_r($params, true) . '...';
+            echo $sql . ' ' . print_r($params, true) . '...';
             $timer = microtime(true);
         }
 

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -429,7 +429,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
     {
         self::wakeup();
         if ($year === null) {
-            $year = int(gmdate('Y'));
+            $year = (int)gmdate('Y');
         }
 
         if ($weekno < 10) {

--- a/src/Classes/ServiceAPI/ServiceAPI.php
+++ b/src/Classes/ServiceAPI/ServiceAPI.php
@@ -163,7 +163,7 @@ abstract class ServiceAPI implements IServiceAPI, MyRadio_DataSource
 
     }
 
-    protected function __destruct()
+    public function __destruct()
     {
         if ($this->change) {
             $this->change = false;

--- a/src/Classes/ServiceAPI/ServiceAPI.php
+++ b/src/Classes/ServiceAPI/ServiceAPI.php
@@ -34,6 +34,8 @@ abstract class ServiceAPI implements IServiceAPI, MyRadio_DataSource
      */
     protected static $cache = null;
 
+    protected $change = false;
+
     /**
      * Start up the connection to the Database
      */
@@ -161,6 +163,14 @@ abstract class ServiceAPI implements IServiceAPI, MyRadio_DataSource
 
     }
 
+    protected function __destruct()
+    {
+        if ($this->change) {
+            $this->change = false;
+            self::$cache->set(self::getCacheKey($this->getID()), $this);
+        }
+    }
+
     /**
      * Generates the Key string for caching services
      *
@@ -179,7 +189,7 @@ abstract class ServiceAPI implements IServiceAPI, MyRadio_DataSource
      */
     protected function updateCacheObject()
     {
-        self::$cache->set(self::getCacheKey($this->getID()), $this);
+        $this->change = true;
     }
 
     /**


### PR DESCRIPTION
- Get rid of ?dbdbg. It was a hack, could actually cause issues if caching was off (would break MyRadio entirely), and the new DB_PROFILE constant means that things can be investigated on the CLI.
- Lazy load some attributes of Timeslots and Users. This should improve perfomance on a cold cache. Disabled caches are still awful in toDataSource scenarios due to getMeta's performance.
- Made cache updates lazy and not apply until destruct time, so multiple edits don't get written at once.