### PR TITLE
Workaround for limit=X00 bug = more music variety.

### DIFF
--- a/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
+++ b/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
@@ -309,7 +309,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
                 'https://ws.audioscrobbler.com/2.0/?method=geo.getTopTracks&api_key='
                 . Config::$lastfm_api_key
                 . '&country=' . Config::$lastfm_geo
-                . '&limit=100&format=json'
+                . '&limit=150&format=json'
             ),
             true
         );
@@ -341,7 +341,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             file_get_contents(
                 'https://ws.audioscrobbler.com/2.0/?method=chart.getTopTracks&api_key='
                 . Config::$lastfm_api_key
-                . '&limit=100&format=json'
+                . '&limit=150&format=json'
             ),
             true
         );
@@ -372,7 +372,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             file_get_contents(
                 'https://ws.audioscrobbler.com/2.0/?method=chart.getHypedTracks&api_key='
                 . Config::$lastfm_api_key
-                . '&limit=100&format=json'
+                . '&limit=150&format=json'
             ),
             true
         );


### PR DESCRIPTION
Like Heart, but actually more music variety. Last.fm has a bug in their API still, which is resulting in weird results for the Worldwide Top Chart. Upping the limit a small amount will fix this, and give a little more variety in the playlists. Groups still not working, so if those are looking like they will never come back we can think about ditching those.