### PR TITLE
It is worse than I thought...

### DIFF
--- a/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
+++ b/src/Classes/Daemons/MyRadio_PlaylistsDaemon.php
@@ -309,7 +309,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
                 'https://ws.audioscrobbler.com/2.0/?method=geo.getTopTracks&api_key='
                 . Config::$lastfm_api_key
                 . '&country=' . Config::$lastfm_geo
-                . '&limit=150&format=json'
+                . '&limit=149&format=json'
             ),
             true
         );
@@ -341,7 +341,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             file_get_contents(
                 'https://ws.audioscrobbler.com/2.0/?method=chart.getTopTracks&api_key='
                 . Config::$lastfm_api_key
-                . '&limit=150&format=json'
+                . '&limit=149&format=json'
             ),
             true
         );
@@ -372,7 +372,7 @@ class MyRadio_PlaylistsDaemon extends \MyRadio\MyRadio\MyRadio_Daemon
             file_get_contents(
                 'https://ws.audioscrobbler.com/2.0/?method=chart.getHypedTracks&api_key='
                 . Config::$lastfm_api_key
-                . '&limit=150&format=json'
+                . '&limit=149&format=json'
             ),
             true
         );


### PR DESCRIPTION
It is actually every multiple of 10. Changing again, this time to 149, which I have checked properly (I thought I had checked 150, but clearly I must have either misseen, or it just broke.) The upshot of these APIs (when they work) is that they are no longer calculated just weekly, so the charts we have should flow more as people listen to their music throughout the week, so suddenly popular songs are reflected instantly, not a full week after they become popular.