### PR TITLE
lazy loading of payments fix

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -1162,7 +1162,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
 
         $amount = number_format($amount, 2);
 
-        foreach ($this->payment as $k => $v) {
+        foreach ($this->getAllPayments() as $k => $v) {
             if ($v['year'] == $year && $v['paid'] == $amount) {
                 return;
             } elseif ($v['year'] == $year) {
@@ -1173,8 +1173,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
                     [(float) $amount, $year, $this->getID()]
                 );
                 $this->payment[$k]['paid'] = $amount;
-                $this->updateCacheObject();
                 $this->permissions = null; // Clear local permissions cache
+                $this->updateCacheObject();
 
                 return;
             }
@@ -1705,7 +1705,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         } else {
             $year = CoreUtils::getAcademicYear();
             self::$db->query('INSERT INTO public.member_year (memberid, year, paid) VALUES ($1, $2, $3)', [$this->getID(), $year, $paid]);
-            $this->payment[] = ['year' => $year, 'paid' => $paid];
+            $this->setPayment($amount, $year);
             $this->updateCacheObject();
             return true;
         }

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -1187,8 +1187,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
             [(float) $amount, $year, $this->getID()]
         );
         $this->payment[] = ['year' => $year, 'amount' => (float) $amount];
-        $this->updateCacheObject();
         $this->permissions = null; // Clear local permissions cache
+        $this->updateCacheObject();
 
         return;
     }
@@ -1704,8 +1704,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
             return true;
         } else {
             $year = CoreUtils::getAcademicYear();
-            self::$db->query('INSERT INTO public.member_year (memberid, year, paid) VALUES ($1, $2, $3)', [$this->getID(), $year, $paid]);
-            $this->setPayment($amount, $year);
+            $this->setPayment($paid, $year);
             $this->updateCacheObject();
             return true;
         }


### PR DESCRIPTION
I'm not actually sure why activateMemberThisYear exists... Maybe it would be useful as a permission block if it didn't take in the payment amount as a variable.