### PR TITLE
getAll() with keys

### DIFF
--- a/src/Classes/APCProvider.php
+++ b/src/Classes/APCProvider.php
@@ -82,18 +82,16 @@ class APCProvider implements \MyRadio\Iface\CacheProvider
         return apc_fetch($this->getKeyPrefix().$key);
     }
 
-    public function getAll($prefix = '')
+    public function getAll($keys)
     {
         if (!$this->enable) {
             return [];
         }
-        
-        $prefix = preg_quote($this->getKeyPrefix() . $prefix);
 
         $result = [];
-        $it = new \APCIterator('user', '/^' . $prefix . '/', APC_ITER_VALUE);
-        foreach ($it as $row) {
-            $result[] = $row['value'];
+
+        foreach ($keys as $key) {
+            $result[] = $this->get($key);
         }
 
         return $result;

--- a/src/Classes/MemcachedProvider.php
+++ b/src/Classes/MemcachedProvider.php
@@ -102,21 +102,24 @@ class MemcachedProvider implements \MyRadio\Iface\CacheProvider
         return $this->memcached->get($this->getKeyPrefix() . $key);
     }
 
-    public function getAll($prefix = '')
+    /**
+     * Fetch all objects from the cache assosicated with the given keys
+     * @param  array $keys cache keys to be fetched
+     * @return mixed[]     array of objects relating to provided keys
+     */
+    public function getAll($keys)
     {
         if (!$this->enable) {
             return [];
         }
 
-        $prefix = $this->getKeyPrefix() . $prefix;
-        $result = [];
-        $len = strlen($prefix);
-        foreach ($this->memcached->getAllKeys() as $key) {
-            if (substr($key, 0, $len) === $prefix) {
-                //Don't use $this->get as it'll append the prefix twice
-                $result[] = $this->memcached->get($key);
-            }
+        $prefix = $this->getKeyPrefix();
+        foreach ($keys as &$key) {
+            $key = $prefix . $key;
         }
+
+        //Don't use $this->get as it'll append the prefix twice
+        $result = $this->memcached->getMulti($keys);
 
         return $result;
     }

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -706,8 +706,10 @@ class MyRadio_Show extends MyRadio_Metadata_Common
     {
         $key = 'MyRadio_Show_AllShowsFetcher_last_' . $show_type_id . '_' . (int) $current_term_only;
 
-        if (self::$cache->get($key)) {
-            $shows = self::$cache->getAll(self::getCacheKey(''));
+        $keys = self::$cache->get($key);
+
+        if ($keys) {
+            $shows = self::$cache->getAll($keys);
         } else {
             $sql = self::BASE_SHOW_SQL . ' WHERE show_type_id=$1';
             $params = [$show_type_id];
@@ -723,13 +725,15 @@ class MyRadio_Show extends MyRadio_Metadata_Common
             $result = self::$db->fetchAll($sql, $params);
 
             $shows = [];
+            $show_keys = [];
             foreach ($result as $row) {
                 $show = new MyRadio_Show($row);
                 $show->updateCacheObject();
                 $shows[] = $show;
+                $show_keys[] = self::getCacheKey($show->getID());
             }
 
-            self::$cache->set($key, 'true');
+            self::$cache->set($key, $show_keys);
         }
 
         return $shows;

--- a/src/Interfaces/CacheProvider.php
+++ b/src/Interfaces/CacheProvider.php
@@ -23,10 +23,10 @@ interface CacheProvider extends Singleton
      */
     public function get($key);
     /**
-     * Gets all cache entries starting with the given prefix
+     * Gets all cache entries using the given keys
      * @return Array
      */
-    public function getAll($prefix = '');
+    public function getAll($keys);
     /**
      * Deletes a cache entry
      */


### PR DESCRIPTION
should fix the problems with getAllKeys() which is a fairly useless function:
"This is not an atomic operation, so it isn't a truly consistent snapshot of the keys at point in time. As memcache doesn't guarantee to return all keys you also cannot assume that all keys have been returned."
Every so often it would just return false when keys existed.

With this we keep a list of keys to be fetched then fetch them.