### PR TITLE
Api mixin fun

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Alias.php
+++ b/src/Classes/ServiceAPI/MyRadio_Alias.php
@@ -149,7 +149,7 @@ class MyRadio_Alias extends ServiceAPI
         $data = [
             'alias_id' => $this->getID(),
             'source' => $this->getSource(),
-            'destinations' => CoreUtils::dataSourceParser($this->getDestinations())
+            'destinations' => CoreUtils::dataSourceParser($this->getDestinations(), $mixins)
         ];
 
         return $data;

--- a/src/Classes/ServiceAPI/MyRadio_Officer.php
+++ b/src/Classes/ServiceAPI/MyRadio_Officer.php
@@ -728,10 +728,10 @@ class MyRadio_Officer extends ServiceAPI
             'permissions' => function(&$data) {
                 $data['permissions'] = $this->getPermissions();
             },
-            'history' => function(&$data) {
+            'history' => function(&$data, $mixins) {
                 $data['history'] = CoreUtils::dataSourceParser($this->getHistory(), $mixins);
             },
-            'current' => function(&$data) {
+            'current' => function(&$data, $mixins) {
                 $data['current'] = CoreUtils::dataSourceParser($this->getCurrentHolders(), $mixins);
             }
         ];

--- a/src/Classes/ServiceAPI/MyRadio_Officer.php
+++ b/src/Classes/ServiceAPI/MyRadio_Officer.php
@@ -729,10 +729,10 @@ class MyRadio_Officer extends ServiceAPI
                 $data['permissions'] = $this->getPermissions();
             },
             'history' => function(&$data) {
-                $data['history'] = CoreUtils::dataSourceParser($this->getHistory());
+                $data['history'] = CoreUtils::dataSourceParser($this->getHistory(), $mixins);
             },
             'current' => function(&$data) {
-                $data['current'] = CoreUtils::dataSourceParser($this->getCurrentHolders());
+                $data['current'] = CoreUtils::dataSourceParser($this->getCurrentHolders(), $mixins);
             }
         ];
 

--- a/src/Classes/ServiceAPI/ServiceAPI.php
+++ b/src/Classes/ServiceAPI/ServiceAPI.php
@@ -93,11 +93,11 @@ abstract class ServiceAPI implements IServiceAPI, MyRadio_DataSource
         return new $class($itemid);
     }
 
-    protected function addMixins(&$data, $mixins, $mixin_funcs, $strict = true) {
+    protected function addMixins(&$data, $mixins, $mixin_funcs, $strict = false) {
         foreach ($mixins as $mixin) {
             if (array_key_exists($mixin, $mixin_funcs)) {
                 $mixin_funcs[$mixin]($data);
-            } else {
+            } elseif ($strict) {
                 throw new MyRadioException('Unsupported mixin ' . $mixin, 400);
             }
         }

--- a/src/Classes/ServiceAPI/ServiceAPI.php
+++ b/src/Classes/ServiceAPI/ServiceAPI.php
@@ -96,7 +96,7 @@ abstract class ServiceAPI implements IServiceAPI, MyRadio_DataSource
     protected function addMixins(&$data, $mixins, $mixin_funcs, $strict = false) {
         foreach ($mixins as $mixin) {
             if (array_key_exists($mixin, $mixin_funcs)) {
-                $mixin_funcs[$mixin]($data);
+                $mixin_funcs[$mixin]($data, $mixins);
             } elseif ($strict) {
                 throw new MyRadioException('Unsupported mixin ' . $mixin, 400);
             }


### PR DESCRIPTION
This PR solves issues that were blocking aliasgen, namely not being able to pass the `personal_data` mixin for `MyRadio_User` 'through' api methods in classes that return nested data from `MyRadio_User`.
I have solved it by disabling checks for mixin names by default, and by somewhat hackily blindly passing the array of mixins through to these nested 'sub models'.