### PR TITLE
change show credits to array and remove deprecated $full

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -863,12 +863,19 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         return self::resultSetToObjArray($r);
     }
 
-    public function toDataSource($full = true)
+    public function toDataSource()
     {
         $data = [
             'show_id' => $this->getID(),
             'title' => $this->getMeta('title'),
-            'credits' => implode(', ', $this->getCreditsNames(false)),
+            'credits' => array_map(
+                function ($x) {
+                    $x['User'] = $x['User']->toDataSource();
+
+                    return $x;
+                },
+                $this->getCredits()
+            ),
             'description' => $this->getMeta('description'),
             'show_type_id' => $this->show_type,
             'seasons' => [
@@ -897,17 +904,6 @@ class MyRadio_Show extends MyRadio_Metadata_Common
             ],
             'photo' => $this->getShowPhoto(),
         ];
-
-        if ($full) {
-            $data['credits'] = array_map(
-                function ($x) {
-                    $x['User'] = $x['User']->toDataSource();
-
-                    return $x;
-                },
-                $this->getCredits()
-            );
-        }
 
         return $data;
     }

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -868,6 +868,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         $data = [
             'show_id' => $this->getID(),
             'title' => $this->getMeta('title'),
+            'credits_string' => implode(', ', $this->getCreditsNames(false)),
             'credits' => array_map(
                 function ($x) {
                     $x['User'] = $x['User']->toDataSource();

--- a/src/Public/js/myradio.scheduler.timeslotlist.js
+++ b/src/Public/js/myradio.scheduler.timeslotlist.js
@@ -10,9 +10,13 @@ $('.twig-datatable').dataTable(
             "sTitle": "Title",
             "sClass": "left"
         },
-        //credits
+        //credits_string
         {
             "sTitle": "Credits",
+            "bVisible": false
+        },
+        //credits
+        {
             "bVisible": false
         },
         //description

--- a/src/Public/js/myury.scheduler.pending.js
+++ b/src/Public/js/myury.scheduler.pending.js
@@ -10,9 +10,13 @@ $('.twig-datatable').dataTable(
             "sTitle": "Title",
             "sClass": "left"
         },
-        //credits
+        //credits_string
         {
             "sTitle": "Credits"
+        },
+        //credits
+        {
+            "bVisible": false
         },
         //description
         {

--- a/src/Public/js/myury.scheduler.seasonlist.js
+++ b/src/Public/js/myury.scheduler.seasonlist.js
@@ -10,9 +10,13 @@ $('.twig-datatable').dataTable(
             "sTitle": "Title",
             "sClass": "left"
         },
-        //credits
+        //credits_string
         {
             "sTitle": "Credits"
+        },
+        //credits
+        {
+            "bVisible": false
         },
         //description
         {

--- a/src/Public/js/myury.scheduler.showlist.js
+++ b/src/Public/js/myury.scheduler.showlist.js
@@ -9,9 +9,13 @@ $('.twig-datatable').dataTable(
         {
             "sTitle" : "Title"
         },
+        //credits_string
+        {
+            "sTitle": "Credits"
+        },
         //credits
         {
-            "sTitle" : "Credits"
+            "bVisible": false
         },
         //description
         {

--- a/src/Public/js/myury.stats.mostlistenedtimeslot.js
+++ b/src/Public/js/myury.stats.mostlistenedtimeslot.js
@@ -7,10 +7,14 @@ $('.twig-datatable').dataTable(
             "sTitle": "Title",
             "sClass": "left"
         },
-        //credits
+        //credits_string
         {
             "sTitle": "Credits",
             "bVisible": true
+        },
+        //credits
+        {
+            "bVisible": false
         },
         //description
         {

--- a/src/Public/js/myury.stats.mostmessagedtimeslot.js
+++ b/src/Public/js/myury.stats.mostmessagedtimeslot.js
@@ -7,10 +7,14 @@ $('.twig-datatable').dataTable(
             "sTitle": "Title",
             "sClass": "left"
         },
-        //credits
+        //credits_string
         {
             "sTitle": "Credits",
             "bVisible": true
+        },
+        //credits
+        {
+            "bVisible": false
         },
         //description
         {


### PR DESCRIPTION
This may have ramifications for things that request shows - potentially mixclouder. However everything apart from 'searchMeta' should have already been receiving arrays