### PR TITLE
WIP: Make API use timestamps everywhere

### DIFF
--- a/src/Classes/Config.php
+++ b/src/Classes/Config.php
@@ -468,7 +468,7 @@ final class Config
     public static $yusu_api_key;
 
     /**
-     * The web address (up to the endpoint) where the YUSU API lives. It changes from time 
+     * The web address (up to the endpoint) where the YUSU API lives. It changes from time
      * to time so check that the API calls are actually succeeding now and then.
      */
     public static $yusu_api_website;

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -496,7 +496,12 @@ class CoreUtils
         $return = [];
         $return[] = ['Timestamp', 'Errors per request', 'Exceptions per request', 'Queries per request'];
         foreach ($result as $row) {
-            $return[] = [self::happyTime($row['timestamp'], true, false), (int) $row['errors'], (int) $row['exceptions'], (int) $row['queries']];
+            $return[] = [
+                self::happyTime($row['timestamp'], true, false),
+                (int) $row['errors'],
+                (int) $row['exceptions'],
+                (int) $row['queries']
+            ];
         }
 
         return $return;

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -148,19 +148,26 @@ class CoreUtils
 
     /**
      * Returns a postgresql-formatted timestamp.
-     *
-     * @param int $time The time to get the timestamp for. Default right now.
-     *
+     * @param int $time The time to get the timestamp for. Defaults to "now".
      * @return string a timestamp
      * @assert (30) == '1970-01-01 00:00:30'
      */
     public static function getTimestamp($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
-
+        if (!isset($time)) $time = time();
         return gmdate('Y-m-d H:i:s+00', $time);
+    }
+
+    /**
+     * Returns a postgresql-formatted duration.
+     * @param int $time The time to get the duration for. Defaults to "now".
+     * @return string a duration
+     * @assert (4242) == '01:10:42'
+     */
+    public static function getDuration($time = null)
+    {
+        if (!isset($time)) $time = time();
+        return gmdate('H:i:s', $time);
     }
 
     /**

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -121,7 +121,8 @@ class CoreUtils
      */
     public static function happyTime($timestring, $time = true, $date = true)
     {
-        return date(($date ? 'd/m/Y' : '').($time && $date ? ' ' : '').($time ? 'H:i' : ''), is_numeric($timestring) ? $timestring : strtotime($timestring));
+        $formatstring = ($date ? 'd/m/Y' : '') . ($time && $date ? ' ' : '') . ($time ? 'H:i' : '');
+        return date($formatstring, is_numeric($timestring) ? $timestring : strtotime($timestring));
     }
 
     /**

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -121,7 +121,7 @@ class CoreUtils
      */
     public static function happyTime($timestring, $time = true, $date = true)
     {
-        $formatstring = ($date ? 'd/m/Y' : '') . ($time && $date ? ' ' : '') . ($time ? 'H:i' : '');
+        $formatstring = ($date ? 'd/m/Y' : '') . ($time && $date ? ' ' : '') . ($time ? 'H:i:s' : '');
         return date($formatstring, is_numeric($timestring) ? $timestring : strtotime($timestring));
     }
 

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -168,7 +168,7 @@ class CoreUtils
     public static function getDuration($time = null)
     {
         if (!isset($time)) $time = time();
-        return gmdate('H:i:s', $time);
+        return gmdate('H:i:s+00', $time);
     }
 
     /**
@@ -496,7 +496,7 @@ class CoreUtils
         $return = [];
         $return[] = ['Timestamp', 'Errors per request', 'Exceptions per request', 'Queries per request'];
         foreach ($result as $row) {
-            $return[] = [date('H:i', $row['timestamp']), (int) $row['errors'], (int) $row['exceptions'], (int) $row['queries']];
+            $return[] = [self::happyTime($row['timestamp'], true, false), (int) $row['errors'], (int) $row['exceptions'], (int) $row['queries']];
         }
 
         return $return;

--- a/src/Classes/MyRadio/MyRadioNews.php
+++ b/src/Classes/MyRadio/MyRadioNews.php
@@ -75,7 +75,7 @@ class MyRadioNews
         $db = Database::getInstance();
 
         $news = $db->fetchOne(
-            'SELECT newsentryid, fname || \' \' || sname AS author, timestamp AS posted, content
+            'SELECT newsentryid, fname || \' \' || sname AS author, EXTRACT(epoch FROM timestamp) AS posted, content
             FROM public.news_feed, public.member
             WHERE newsentryid=$1
             AND news_feed.memberid = member.memberid',

--- a/src/Classes/MyRadio/MyRadioNews.php
+++ b/src/Classes/MyRadio/MyRadioNews.php
@@ -91,11 +91,8 @@ class MyRadioNews
             [
                 'seen' => $db->fetchOne(
                     'SELECT seen FROM public.member_news_feed
-                    WHERE newsentryid=$1 AND memberid=$2 LIMIT 1',
-                    [
-                        $news['newsentryid'],
-                        empty($user) ? 0 : $user->getID(),
-                    ]
+                    WHERE newsentryid=$1 AND memberid=$2',
+                    [$news['newsentryid'], empty($user) ? 0 : $user->getID()]
                 ),
                 'posted' => CoreUtils::happyTime($news['posted']),
             ]

--- a/src/Classes/MyRadioEmail.php
+++ b/src/Classes/MyRadioEmail.php
@@ -46,7 +46,11 @@ class MyRadioEmail extends ServiceAPI
     {
         self::$db = Database::getInstance();
 
-        $info = self::$db->fetchOne('SELECT * FROM mail.email WHERE email_id=$1', [$eid]);
+        $info = self::$db->fetchOne(
+            'SELECT subject, body, sender, timestamp
+             FROM mail.email WHERE email_id=$1',
+            [$eid]
+        );
 
         if (empty($info)) {
             throw new MyRadioException('Email '.$eid.' does not exist!');
@@ -55,7 +59,7 @@ class MyRadioEmail extends ServiceAPI
         $this->subject = $info['subject'];
         $this->body = $info['body'];
         $this->from = (empty($info['sender']) ? null : MyRadio_User::getInstance($info['sender']));
-        $this->timestamp = strtotime($info['timestamp']);
+        $this->timestamp = $info['timestamp'];
         $this->email_id = $eid;
 
         $this->r_users = self::$db->fetchColumn('SELECT memberid FROM mail.email_recipient_member WHERE email_id=$1', [$eid]);

--- a/src/Classes/ServiceAPI/MyRadio_APIKey.php
+++ b/src/Classes/ServiceAPI/MyRadio_APIKey.php
@@ -41,8 +41,10 @@ class MyRadio_APIKey extends ServiceAPI implements APICaller
         $this->key = $key;
         $revoked = self::$db->fetchColumn('SELECT revoked from myury.api_key WHERE key_string=$1', [$key]);
         $this->revoked = ($revoked[0] == 't');
-        $this->permissions = self::$db->fetchColumn('SELECT typeid FROM myury.api_key_auth WHERE key_string=$1',
-                                                    [$key]);
+        $this->permissions = self::$db->fetchColumn(
+            'SELECT typeid FROM myury.api_key_auth WHERE key_string=$1',
+            [$key]
+        );
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_APIKey.php
+++ b/src/Classes/ServiceAPI/MyRadio_APIKey.php
@@ -41,7 +41,8 @@ class MyRadio_APIKey extends ServiceAPI implements APICaller
         $this->key = $key;
         $revoked = self::$db->fetchColumn('SELECT revoked from myury.api_key WHERE key_string=$1', [$key]);
         $this->revoked = ($revoked[0] == 't');
-        $this->permissions = self::$db->fetchColumn('SELECT typeid FROM myury.api_key_auth WHERE key_string=$1', [$key]);
+        $this->permissions = self::$db->fetchColumn('SELECT typeid FROM myury.api_key_auth WHERE key_string=$1',
+                                                    [$key]);
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_Album.php
+++ b/src/Classes/ServiceAPI/MyRadio_Album.php
@@ -171,7 +171,7 @@ class MyRadio_Album extends ServiceAPI
      * Update the Artist for this Album.
      *
      * @param string $artist        The Artist name
-     * @param bool   $applyToTracks If true, this will update the Artist for each individual Track in the Album. Default false.
+     * @param bool   $applyToTracks If true, this will update the Artist for each individual Track in the Album.
      *                              Default false.
      *
      * @return \MyRadio_Album

--- a/src/Classes/ServiceAPI/MyRadio_Album.php
+++ b/src/Classes/ServiceAPI/MyRadio_Album.php
@@ -61,11 +61,16 @@ class MyRadio_Album extends ServiceAPI
         $this->albumid = (int) $recordid;
 
         $result = self::$db->fetchOne(
-            'SELECT * FROM (SELECT * FROM public.rec_record WHERE recordid=$1 LIMIT 1) AS t1
-            LEFT JOIN public.rec_statuslookup ON t1.status = rec_statuslookup.status_code
-            LEFT JOIN public.rec_medialookup ON t1.media = rec_medialookup.media_code
-            LEFT JOIN public.rec_formatlookup ON t1.format = rec_formatlookup.format_code
-            LEFT JOIN public.rec_locationlookup ON t1.location = rec_locationlookup.location_code',
+            'SELECT title, artist, status_descr, media_descr, format_descr, recordlabel,
+               EXTRACT(epoch FROM dateadded) AS dateadded, EXTRACT(epoch FROM datereleased) AS datereleased,
+               shelfnumber, shelfletter, memberid_add, memberid_edit,
+               EXTRACT(epoch FROM datetime_lastedit) AS datetime_lastedit, cdid, location_descr
+             FROM public.rec_record
+             LEFT JOIN public.rec_statuslookup ON status = rec_statuslookup.status_code
+             LEFT JOIN public.rec_medialookup ON media = rec_medialookup.media_code
+             LEFT JOIN public.rec_formatlookup ON format = rec_formatlookup.format_code
+             LEFT JOIN public.rec_locationlookup ON location = rec_locationlookup.location_code
+             WHERE recordid=$1',
             [$recordid]
         );
 
@@ -81,13 +86,13 @@ class MyRadio_Album extends ServiceAPI
         $this->media = $result['media_descr'];
         $this->format = $result['format_descr'];
         $this->record_label = $result['recordlabel'];
-        $this->date_added = strtotime($result['dateadded']);
-        $this->date_released = strtotime($result['datereleased']);
+        $this->date_added = (int) $result['dateadded'];
+        $this->date_released = (int) $result['datereleased'];
         $this->shelf_number = (int) $result['shelfnumber'];
         $this->shelf_letter = $result['shelfletter'];
         $this->member_add = empty($result['memberid_add']) ? null : (int) $result['memberid_add'];
         $this->member_edit = empty($result['memberid_edit']) ? null : (int) $result['memberid_edit'];
-        $this->last_modified = strtotime($result['datetime_lastedit']);
+        $this->last_modified = (int) $result['datetime_lastedit'];
         $this->cdid = $result['cdid'];
         $this->location = $result['location_descr'];
 
@@ -416,10 +421,10 @@ class MyRadio_Album extends ServiceAPI
             'recordid' => $this->getID(),
             'artist' => $this->artist,
             'cdid' => $this->cdid,
-            'date_added' => CoreUtils::happyTime($this->date_added),
-            'date_released' => CoreUtils::happyTime($this->date_released, false),
+            'date_added' => $this->date_added,
+            'date_released' => $this->date_released,
             'format' => $this->format,
-            'last_modified' => CoreUtils::happyTime($this->last_modified),
+            'last_modified' => $this->last_modified,
             'location' => $this->location,
             'media' => $this->media,
             'member_add' => $this->member_add,

--- a/src/Classes/ServiceAPI/MyRadio_Banner.php
+++ b/src/Classes/ServiceAPI/MyRadio_Banner.php
@@ -239,7 +239,8 @@ class MyRadio_Banner extends MyRadio_Photo
         }
 
         $this->type = $type;
-        self::$db->query('UPDATE website.banner SET banner_type_id=$1 WHERE banner_id=$2', [$type, $this->getBannerID()]);
+        self::$db->query('UPDATE website.banner SET banner_type_id=$1 WHERE banner_id=$2',
+                         [$type, $this->getBannerID()]);
 
         return $this;
     }

--- a/src/Classes/ServiceAPI/MyRadio_Banner.php
+++ b/src/Classes/ServiceAPI/MyRadio_Banner.php
@@ -239,8 +239,10 @@ class MyRadio_Banner extends MyRadio_Photo
         }
 
         $this->type = $type;
-        self::$db->query('UPDATE website.banner SET banner_type_id=$1 WHERE banner_id=$2',
-                         [$type, $this->getBannerID()]);
+        self::$db->query(
+            'UPDATE website.banner SET banner_type_id=$1 WHERE banner_id=$2',
+            [$type, $this->getBannerID()]
+        );
 
         return $this;
     }

--- a/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
+++ b/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
@@ -89,7 +89,8 @@ class MyRadio_BannerCampaign extends ServiceAPI
     {
         $this->banner_campaign_id = (int) $banner_campaign_id;
 
-        $result = self::$db->fetchOne('SELECT * FROM website.banner_campaign WHERE banner_campaign_id=$1', [$banner_campaign_id]);
+        $result = self::$db->fetchOne('SELECT * FROM website.banner_campaign WHERE banner_campaign_id=$1',
+                                      [$banner_campaign_id]);
         if (empty($result)) {
             throw new MyRadioException('Banner Campaign '.$banner_campaign_id.' does not exist!');
         }
@@ -449,7 +450,8 @@ class MyRadio_BannerCampaign extends ServiceAPI
     }
 
     /**
-     * Gets all Banner Campaigns that are currently live. That is they are active and have timeslots at the current time.
+     * Gets all Banner Campaigns that are currently live.
+     * That is they are active and have timeslots at the current time.
      *
      * @return MyRadio_BannerCampaign[]
      */

--- a/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
+++ b/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
@@ -91,10 +91,11 @@ class MyRadio_BannerCampaign extends ServiceAPI
 
         $result = self::$db->fetchOne(
             'SELECT banner_id, memberid, approvedid, banner_location_id,
-               EXTRACT(epoch FROM effective_from), EXTRACT(epoch FROM effective_to)
-             FROM website.banner_campaign
-             WHERE banner_campaign_id=$1',
-            [$banner_campaign_id]);
+              EXTRACT(epoch FROM effective_from), EXTRACT(epoch FROM effective_to)
+            FROM website.banner_campaign
+            WHERE banner_campaign_id=$1',
+            [$banner_campaign_id]
+        );
         if (empty($result)) {
             throw new MyRadioException('Banner Campaign '.$banner_campaign_id.' does not exist!');
         }

--- a/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
+++ b/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
@@ -457,15 +457,15 @@ class MyRadio_BannerCampaign extends ServiceAPI
     {
         return self::resultSetToObjArray(
             self::$db->fetchColumn(
-                'SELECT website.banner_campaign.banner_campaign_id FROM website.banner_campaign, website.banner_timeslot
-                WHERE website.banner_campaign.banner_campaign_id = website.banner_timeslot.banner_campaign_id
-                AND effective_from < now()
-                AND (effective_to IS NULL
-                    OR effective_to > now())
-                AND day = EXTRACT(ISODOW FROM now())
-                AND start_time < localtime
-                AND end_time > localtime
-                ORDER BY "order" ASC'
+                'SELECT banner_campaign_id FROM website.banner_campaign
+                 LEFT JOIN website.banner_timeslot USING(banner_campaign_id)
+                 WHERE effective_from < now()
+                 AND (effective_to IS NULL
+                      OR effective_to > now())
+                 AND day = EXTRACT(ISODOW FROM now())
+                 AND start_time < localtime
+                 AND end_time > localtime
+                 ORDER BY "order" ASC'
             )
         );
     }

--- a/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
+++ b/src/Classes/ServiceAPI/MyRadio_BannerCampaign.php
@@ -355,9 +355,6 @@ class MyRadio_BannerCampaign extends ServiceAPI
      */
     public function addTimeslot($day, $start, $end)
     {
-        $start = gmdate('H:i:s', $start).'+00';
-        $end = gmdate('H:i:s', $end).'+00';
-
         $id = self::$db->fetchColumn(
             'INSERT INTO website.banner_timeslot
             (banner_campaign_id, memberid, approvedid, "order", day, start_time, end_time)
@@ -366,16 +363,16 @@ class MyRadio_BannerCampaign extends ServiceAPI
                 $this->getID(),
                 MyRadio_User::getInstance()->getID(),
                 $day,
-                $start,
-                $end,
+                CoreUtils::getDuration($start),
+                CoreUtils::getDuration($end),
             ]
         )[0];
 
         $this->timeslots[] = [
             'id' => $id,
             'day' => $day,
-            'start_time' => strtotime($start, 0),
-            'end_time' => strtotime($end, 0),
+            'start_time' => $start,
+            'end_time' => $end,
         ];
 
         $this->updateCacheObject();

--- a/src/Classes/ServiceAPI/MyRadio_ChartRelease.php
+++ b/src/Classes/ServiceAPI/MyRadio_ChartRelease.php
@@ -302,9 +302,9 @@ class MyRadio_ChartRelease extends ServiceAPI
      */
     public function setReleaseTime($release_time)
     {
-        $this->release_time = strtotime($release_time);
+        $this->release_time = intval($release_time);
 
-        return $this->setDB(self::SET_RELEASE_TIME_SQL, date('c', $release_time));
+        return $this->setDB(self::SET_RELEASE_TIME_SQL, date('c', intval($release_time)));
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_ChartRelease.php
+++ b/src/Classes/ServiceAPI/MyRadio_ChartRelease.php
@@ -175,10 +175,7 @@ class MyRadio_ChartRelease extends ServiceAPI
         return array_pop(
             self::$db->fetchColumn(
                 self::FIND_RELEASE_ID_ON_SQL,
-                [
-                    $chart_type_id,
-                    date('c', $release_time),
-                ]
+                [$chart_type_id, CoreUtils::getTimestamp($release_time)]
             )
         );
     }
@@ -283,10 +280,7 @@ class MyRadio_ChartRelease extends ServiceAPI
     {
         $r = self::$db->fetchColumn(
             self::INSERT_SQL,
-            [
-                (int) $data['chart_type_id'],
-                date('c', (int)$data['submitted_time']), // Expecting UNIX timestamp
-            ],
+            [(int) $data['chart_type_id'], CoreUtils::getTimestamp($data['submitted_time'])], // Expecting UNIX timestamp
             true
         );
 
@@ -304,7 +298,7 @@ class MyRadio_ChartRelease extends ServiceAPI
     {
         $this->release_time = intval($release_time);
 
-        return $this->setDB(self::SET_RELEASE_TIME_SQL, date('c', intval($release_time)));
+        return $this->setDB(self::SET_RELEASE_TIME_SQL, CoreUtils::getTimestamp($release_time));
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_ChartRelease.php
+++ b/src/Classes/ServiceAPI/MyRadio_ChartRelease.php
@@ -20,64 +20,39 @@ use MyRadio\MyRadio\MyRadioFormField;
  */
 class MyRadio_ChartRelease extends ServiceAPI
 {
-    const GET_INSTANCE_SQL = '
-        SELECT
-            *
-        FROM
-            music.chart_release
-        WHERE
-            chart_release_id = $1
-        ;';
+    const GET_INSTANCE_SQL =
+        'SELECT chart_release_id, chart_type_id,
+         EXTRACT(epoch FROM submitted) AS submitted
+         FROM music.chart_release
+         WHERE chart_release_id = $1';
 
-    const GET_CHART_ROWS_SQL = '
-        SELECT
-            chart_row_id
-        FROM
-            music.chart_row
-        WHERE
-            chart_release_id = $1
-        ORDER BY
-            position ASC
-        ;';
+    const GET_CHART_ROWS_SQL =
+        'SELECT chart_row_id
+         FROM music.chart_row
+         WHERE chart_release_id = $1
+         ORDER BY position ASC';
 
-    const FIND_RELEASE_ID_ON_SQL = '
-        SELECT
-            chart_release_id
-        FROM
-            music.chart_release
-        WHERE
-            chart_type_id = $1 AND
-            submitted     = $2
-        LIMIT
-            1
-        ;';
+    const FIND_RELEASE_ID_ON_SQL =
+        'SELECT chart_release_id
+        FROM music.chart_release
+        WHERE chart_type_id = $1
+          AND submitted     = $2
+        LIMIT 1';
 
-    const INSERT_SQL = '
-        INSERT INTO
-            music.chart_release(chart_type_id, submitted)
-        VALUES
-            ($1, $2)
-        RETURNING
-            chart_release_id
-        ;';
+    const INSERT_SQL =
+        'INSERT INTO music.chart_release(chart_type_id, submitted)
+        VALUES ($1, $2)
+        RETURNING chart_release_id';
 
-    const SET_RELEASE_TIME_SQL = '
-        UPDATE
-            music.chart_release
-        SET
-            submitted = $1
-        WHERE
-            chart_release_id = $2
-        ;';
+    const SET_RELEASE_TIME_SQL =
+        'UPDATE music.chart_release
+        SET submitted = $1
+        WHERE chart_release_id = $2';
 
-    const SET_CHART_TYPE_ID_SQL = '
-        UPDATE
-            music.chart_release
-        SET
-            chart_type_id = $1
-        WHERE
-            chart_release_id = $2
-        ;';
+    const SET_CHART_TYPE_ID_SQL =
+        'UPDATE music.chart_release
+        SET chart_type_id = $1
+        WHERE chart_release_id = $2';
 
     /**
      * The singleton store for ChartRelease objects.
@@ -142,11 +117,10 @@ class MyRadio_ChartRelease extends ServiceAPI
         );
         if (empty($chart_release_data)) {
             throw new MyRadioException('The specified Chart Release does not seem to exist.');
-
             return;
         }
 
-        $this->release_time = strtotime($chart_release_data['submitted']);
+        $this->release_time = $chart_release_data['submitted'];
         $this->chart_type_id = $chart_release_data['chart_type_id'];
 
         $this->chart_row_ids = self::$db->fetchColumn(
@@ -310,8 +284,8 @@ class MyRadio_ChartRelease extends ServiceAPI
         $r = self::$db->fetchColumn(
             self::INSERT_SQL,
             [
-                intval($data['chart_type_id']),
-                date('%c', intval($data['submitted_time'])), // Expecting UNIX timestamp
+                (int) $data['chart_type_id'],
+                date('c', (int)$data['submitted_time']), // Expecting UNIX timestamp
             ],
             true
         );
@@ -448,7 +422,7 @@ class MyRadio_ChartRelease extends ServiceAPI
     {
         return [
             'type' => $this->getChartType()->getDescription(),
-            'date' => strftime('%c', $this->getReleaseTime()),
+            'date' => $this->getReleaseTime(),
             'editlink' => [
                 'display' => 'icon',
                 'value' => 'pencil',

--- a/src/Classes/ServiceAPI/MyRadio_Demo.php
+++ b/src/Classes/ServiceAPI/MyRadio_Demo.php
@@ -70,11 +70,13 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
     public static function attendingDemo($demoid)
     {
         if (MyRadio_User::getInstance()->hasAuth(AUTH_ADDDEMOS)) {
-            $r = self::$db->fetchColumn('SELECT creditid FROM schedule.show_credit
-                                         WHERE show_id = 0
-                                         AND effective_from=$1
-                                         AND credit_type_id=7',
-                                        [self::getDemoTime($demoid)]);
+            $r = self::$db->fetchColumn(
+                'SELECT creditid FROM schedule.show_credit
+                WHERE show_id = 0
+                  AND effective_from=$1
+                  AND credit_type_id=7',
+                [self::getDemoTime($demoid)]
+            );
             if (empty($r)) {
                 return 'Nobody';
             }
@@ -95,11 +97,15 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
 
     public static function attendingDemoCount($demoid)
     {
-        return self::$db->numRows(self::$db->query('SELECT creditid FROM schedule.show_credit
-                                                    WHERE show_id = 0
-                                                    AND effective_from=$1
-                                                    AND credit_type_id=7',
-                                                   [self::getDemoTime($demoid)]));
+        return self::$db->numRows(
+            self::$db->query(
+                'SELECT creditid FROM schedule.show_credit
+                 WHERE show_id = 0
+                   AND effective_from=$1
+                   AND credit_type_id=7',
+                [self::getDemoTime($demoid)]
+            )
+        );
     }
 
     /**
@@ -193,7 +199,11 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
     public static function getDemoer($demoid)
     {
         self::initDB();
-        $r = self::$db->fetchOne('SELECT memberid FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1', [$demoid]);
+        $r = self::$db->fetchOne(
+            'SELECT memberid FROM schedule.show_season_timeslot
+             WHERE show_season_timeslot_id=$1',
+            [$demoid]
+        );
 
         return MyRadio_User::getInstance($r['memberid']);
     }

--- a/src/Classes/ServiceAPI/MyRadio_Demo.php
+++ b/src/Classes/ServiceAPI/MyRadio_Demo.php
@@ -70,7 +70,11 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
     public static function attendingDemo($demoid)
     {
         if (MyRadio_User::getInstance()->hasAuth(AUTH_ADDDEMOS)) {
-            $r = self::$db->fetchColumn('SELECT creditid FROM schedule.show_credit WHERE show_id = 0 AND effective_from=$1 AND credit_type_id=7', [self::getDemoTime($demoid)]);
+            $r = self::$db->fetchColumn('SELECT creditid FROM schedule.show_credit
+                                         WHERE show_id = 0
+                                         AND effective_from=$1
+                                         AND credit_type_id=7',
+                                        [self::getDemoTime($demoid)]);
             if (empty($r)) {
                 return 'Nobody';
             }
@@ -91,7 +95,11 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
 
     public static function attendingDemoCount($demoid)
     {
-        return self::$db->numRows(self::$db->query('SELECT creditid FROM schedule.show_credit WHERE show_id = 0 AND effective_from=$1 AND credit_type_id=7', [self::getDemoTime($demoid)]));
+        return self::$db->numRows(self::$db->query('SELECT creditid FROM schedule.show_credit
+                                                    WHERE show_id = 0
+                                                    AND effective_from=$1
+                                                    AND credit_type_id=7',
+                                                   [self::getDemoTime($demoid)]));
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_Officer.php
+++ b/src/Classes/ServiceAPI/MyRadio_Officer.php
@@ -435,9 +435,10 @@ class MyRadio_Officer extends ServiceAPI
     {
         if (empty($this->history)) {
             $result = self::$db->fetchAll(
-                'SELECT member_officerid, memberid, '
-                .'from_date, till_date FROM public.member_officer '
-                .'WHERE officerid=$1 ORDER BY from_date DESC',
+                'SELECT member_officerid, memberid, EXTRACT(epoch FROM from_date), EXTRACT(epoch FROM till_date)
+                 FROM public.member_officer
+                 WHERE officerid=$1
+                 ORDER BY from_date DESC',
                 [$this->getID()]
             );
 
@@ -445,9 +446,8 @@ class MyRadio_Officer extends ServiceAPI
                 function ($x) {
                     return [
                         'User' => $x['memberid'],
-                        'from' => strtotime($x['from_date']),
-                        'to' => empty($x['till_date']) ? null
-                            : strtotime($x['till_date']),
+                        'from' => $x['from_date'],
+                        'to' => $x['till_date'] ?: null,
                         'memberofficerid' => (int) $x['member_officerid'],
                     ];
                 },

--- a/src/Classes/ServiceAPI/MyRadio_Photo.php
+++ b/src/Classes/ServiceAPI/MyRadio_Photo.php
@@ -54,17 +54,19 @@ class MyRadio_Photo extends ServiceAPI
         $this->photoid = (int) $photoid;
 
         $result = self::$db->fetchOne(
-            'SELECT * FROM myury.photos WHERE photoid=$1',
+            'SELECT photoid, owner, format,
+             EXTRACT(epoch FROM date_added) AS date_added
+             FROM myury.photos
+             WHERE photoid=$1',
             [$photoid]
         );
         if (empty($result)) {
             throw new MyRadioException('Photo '.$photoid.' does not exist!');
-
             return;
         }
 
         $this->owner = MyRadio_User::getInstance($result['owner']);
-        $this->date_added = strtotime($result['date_added']);
+        $this->date_added = (int) $result['date_added'];
         $this->format = $result['format'];
     }
 
@@ -77,7 +79,7 @@ class MyRadio_Photo extends ServiceAPI
     {
         return [
             'photoid' => $this->getID(),
-            'date_added' => CoreUtils::happyTime($this->getDateAdded()),
+            'date_added' => $this->getDateAdded(),
             'format' => $this->getFormat(),
             'owner' => $this->getOwner()->getID(),
             'url' => $this->getURL(),

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -81,7 +81,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         $this->podcast_id = (int) $podcast_id;
 
         $result = self::$db->fetchOne(
-            'SELECT file, memberid, approvedid, submitted, show_id, (
+            'SELECT file, memberid, approvedid, EXTRACT(epoch FROM submitted) AS submitted, show_id, (
                 SELECT array(
                     SELECT metadata_key_id FROM uryplayer.podcast_metadata
                     WHERE podcast_id=$1 AND effective_from <= NOW()
@@ -129,7 +129,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         $this->file = $result['file'];
         $this->memberid = (int) $result['memberid'];
         $this->approvedid = (int) $result['approvedid'];
-        $this->submitted = strtotime($result['submitted']);
+        $this->submitted = (int) $result['submitted'];
         $this->show_id = (int) $result['show_id'];
 
         //Deal with the Credits arrays

--- a/src/Classes/ServiceAPI/MyRadio_Quote.php
+++ b/src/Classes/ServiceAPI/MyRadio_Quote.php
@@ -191,11 +191,7 @@ class MyRadio_Quote extends ServiceAPI
     {
         self::$db->query(
             self::INSERT_SQL,
-            [
-                $data['text'],
-                $data['source']->getID(),
-                date('c', (int) $data['date']), // Expecting UNIX timestamp
-            ],
+            [$data['text'], $data['source']->getID(), CoreUtils::getTimestamp($data['date'])], // Expecting UNIX timestamp
             true
         );
     }

--- a/src/Classes/ServiceAPI/MyRadio_Quote.php
+++ b/src/Classes/ServiceAPI/MyRadio_Quote.php
@@ -18,57 +18,35 @@ use MyRadio\MyRadio\MyRadioFormField;
  */
 class MyRadio_Quote extends ServiceAPI
 {
-    const GET_INSTANCE_SQL = '
-        SELECT
-            *
-        FROM
-            people.quote
-        WHERE
-            quote_id = $1
-        ;';
+    const GET_INSTANCE_SQL =
+        'SELECT quote_id, text, source,
+         EXTRACT(epoch FROM date) AS date
+         FROM people.quote
+         WHERE quote_id = $1';
 
-    const GET_ALL_SQL = '
-        SELECT
-            quote_id
-        FROM
-            people.quote
-        ORDER BY
-            date DESC
-        ;';
+    const GET_ALL_SQL =
+        'SELECT quote_id
+         FROM people.quote
+         ORDER BY date DESC';
 
-    const INSERT_SQL = '
-        INSERT INTO
-            people.quote(text, source, date)
-        VALUES
-            ($1, $2, $3);
-        ;';
+    const INSERT_SQL =
+        'INSERT INTO people.quote(text, source, date)
+         VALUES ($1, $2, $3)';
 
-    const SET_TEXT_SQL = '
-        UPDATE
-            people.quote
-        SET
-            text = $1
-        WHERE
-            quote_id = $2;
-        ;';
+    const SET_TEXT_SQL =
+        'UPDATE people.quote
+         SET text = $1
+         WHERE quote_id = $2';
 
-    const SET_SOURCE_SQL = '
-        UPDATE
-            people.quote
-        SET
-            source = $1
-        WHERE
-            quote_id = $2
-        ;';
+    const SET_SOURCE_SQL =
+        'UPDATE people.quote
+         SET source = $1
+         WHERE quote_id = $2';
 
-    const SET_DATE_SQL = '
-        UPDATE
-            people.quote
-        SET
-            date = $1
-        WHERE
-            quote_id = $2
-        ;';
+    const SET_DATE_SQL =
+        'UPDATE people.quote
+         SET date = $1
+         WHERE quote_id = $2';
 
     /**
      * The quote ID.
@@ -129,7 +107,7 @@ class MyRadio_Quote extends ServiceAPI
         $this->id = (int) $quote_id;
         $this->text = $quote_data['text'];
         $this->source = MyRadio_User::getInstance($quote_data['source']);
-        $this->date = strtotime($quote_data['date']);
+        $this->date = (int) $quote_data['date'];
     }
 
     /**
@@ -216,7 +194,7 @@ class MyRadio_Quote extends ServiceAPI
             [
                 $data['text'],
                 $data['source']->getID(),
-                date('%c', intval($data['date'])), // Expecting UNIX timestamp
+                date('c', (int) $data['date']), // Expecting UNIX timestamp
             ],
             true
         );
@@ -344,7 +322,7 @@ class MyRadio_Quote extends ServiceAPI
         return [
             'id' => $this->getID(),
             'source' => $this->getSource()->getName(),
-            'date' => strftime('%F', $this->getDate()),
+            'date' => $this->getDate(),
             'text' => $this->getText(),
             'html' => [
                 'display' => 'html',

--- a/src/Classes/ServiceAPI/MyRadio_Selector.php
+++ b/src/Classes/ServiceAPI/MyRadio_Selector.php
@@ -215,15 +215,12 @@ class MyRadio_Selector
      */
     public static function getStudioAtTime($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
+        if (!isset($time)) $time = time();
 
-        $result = Database::getInstance()->fetchColumn(
+        $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
             AND action >= 4 AND action <= 11
-            ORDER BY time DESC
-            LIMIT 1',
+            ORDER BY time DESC',
             [CoreUtils::getTimestamp($time)]
         );
 
@@ -231,7 +228,7 @@ class MyRadio_Selector
             return 0;
         }
 
-        return $result[0] - 3;
+        return $result['action'] - 3;
     }
 
     /**
@@ -243,15 +240,12 @@ class MyRadio_Selector
      */
     public static function getSetbyAtTime($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
+        if (!isset($time)) $time = time();
 
-        $result = Database::getInstance()->fetchColumn(
+        $result = Database::getInstance()->fetchOne(
             'SELECT setby FROM public.selector WHERE time <= $1
             AND action >= 4 AND action <= 11
-            ORDER BY time DESC
-            LIMIT 1',
+            ORDER BY time DESC',
             [CoreUtils::getTimestamp($time)]
         );
 
@@ -259,7 +253,7 @@ class MyRadio_Selector
             return 0;
         }
 
-        return (int) $result[0];
+        return (int) $result['setby'];
     }
 
     /**
@@ -271,15 +265,12 @@ class MyRadio_Selector
      */
     public static function getStudio1PowerAtTime($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
+        if (!isset($time)) $time = time();
 
-        $result = Database::getInstance()->fetchColumn(
+        $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
             AND action >= 13 AND action <= 14
-            ORDER BY time DESC
-            LIMIT 1',
+            ORDER BY time DESC',
             [CoreUtils::getTimestamp($time)]
         );
 
@@ -287,7 +278,7 @@ class MyRadio_Selector
             return false;
         }
 
-        return ($result[0] == 13) ? true : false;
+        return $result['action'] == 13;
     }
 
     /**
@@ -299,15 +290,12 @@ class MyRadio_Selector
      */
     public static function getStudio2PowerAtTime($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
+        if (!isset($time)) $time = time();
 
-        $result = Database::getInstance()->fetchColumn(
+        $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
             AND action >= 15 AND action <= 16
-            ORDER BY time DESC
-            LIMIT 1',
+            ORDER BY time DESC',
             [CoreUtils::getTimestamp($time)]
         );
 
@@ -315,7 +303,7 @@ class MyRadio_Selector
             return false;
         }
 
-        return ($result[0] == 15) ? true : false;
+        return $result['action'] == 15;
     }
 
     /**
@@ -327,11 +315,9 @@ class MyRadio_Selector
      */
     public static function getLockAtTime($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
+        if (!isset($time)) $time = time();
 
-        $result = Database::getInstance()->fetchColumn(
+        $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
             AND action >= 1 AND action <= 3
             ORDER BY time DESC
@@ -343,7 +329,7 @@ class MyRadio_Selector
             return false;
         }
 
-        return ($result[0] == 3) ? 0 : (int) $result[0];
+        return ($result['action'] == 3) ? 0 : (int) $result['action'];
     }
 
     /**
@@ -355,14 +341,11 @@ class MyRadio_Selector
      */
     public static function getLastModAtTime($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
+        if (!isset($time)) $time = time();
 
-        $result = Database::getInstance()->fetchColumn(
+        $result = Database::getInstance()->fetchOne(
             'SELECT time FROM public.selector WHERE time <= $1
-            ORDER BY time DESC
-            LIMIT 1',
+            ORDER BY time DESC',
             [CoreUtils::getTimestamp($time)]
         );
 
@@ -370,7 +353,7 @@ class MyRadio_Selector
             return 1;
         }
 
-        return strtotime($result[0]);
+        return $result['time'];
     }
 
     /**
@@ -382,9 +365,7 @@ class MyRadio_Selector
      */
     public static function getStatusAtTime($time = null)
     {
-        if ($time === null) {
-            $time = time();
-        }
+        if (!isset($time)) $time = time();
 
         $status = self::remoteStreams();
 
@@ -495,13 +476,13 @@ class MyRadio_Selector
     public static function isSilence()
     {
         $result = Database::getInstance()->fetchOne(
-            'SELECT starttime, stoptime
+            'SELECT EXTRACT(epoch FROM starttime) AS starttime, EXTRACT(epoch FROM stoptime) AS stoptime
             FROM jukebox.silence_log
-            ORDER BY silenceid DESC LIMIT 1'
+            ORDER BY silenceid DESC'
         );
 
         if (empty($result['stoptime'])) {
-            return time() - strtotime($result['starttime']);
+            return time() - $result['starttime'];
         } else {
             return 0;
         }

--- a/src/Classes/ServiceAPI/MyRadio_Selector.php
+++ b/src/Classes/ServiceAPI/MyRadio_Selector.php
@@ -215,7 +215,9 @@ class MyRadio_Selector
      */
     public static function getStudioAtTime($time = null)
     {
-        if (!isset($time)) $time = time();
+        if (!isset($time)) {
+            $time = time();
+        }
 
         $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
@@ -240,7 +242,9 @@ class MyRadio_Selector
      */
     public static function getSetbyAtTime($time = null)
     {
-        if (!isset($time)) $time = time();
+        if (!isset($time)) {
+            $time = time();
+        }
 
         $result = Database::getInstance()->fetchOne(
             'SELECT setby FROM public.selector WHERE time <= $1
@@ -265,7 +269,9 @@ class MyRadio_Selector
      */
     public static function getStudio1PowerAtTime($time = null)
     {
-        if (!isset($time)) $time = time();
+        if (!isset($time)) {
+            $time = time();
+        }
 
         $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
@@ -290,7 +296,9 @@ class MyRadio_Selector
      */
     public static function getStudio2PowerAtTime($time = null)
     {
-        if (!isset($time)) $time = time();
+        if (!isset($time)) {
+            $time = time();
+        }
 
         $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
@@ -315,7 +323,9 @@ class MyRadio_Selector
      */
     public static function getLockAtTime($time = null)
     {
-        if (!isset($time)) $time = time();
+        if (!isset($time)) {
+            $time = time();
+        }
 
         $result = Database::getInstance()->fetchOne(
             'SELECT action FROM public.selector WHERE time <= $1
@@ -341,7 +351,9 @@ class MyRadio_Selector
      */
     public static function getLastModAtTime($time = null)
     {
-        if (!isset($time)) $time = time();
+        if (!isset($time)) {
+            $time = time();
+        }
 
         $result = Database::getInstance()->fetchOne(
             'SELECT time FROM public.selector WHERE time <= $1
@@ -365,7 +377,9 @@ class MyRadio_Selector
      */
     public static function getStatusAtTime($time = null)
     {
-        if (!isset($time)) $time = time();
+        if (!isset($time)) {
+            $time = time();
+        }
 
         $status = self::remoteStreams();
 

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -26,7 +26,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
     const BASE_SHOW_SQL =
         'SELECT show_id,
             show.show_type_id,
-            show.submitted,
+            EXTRACT(epoch FROM show.submitted),
             show.memberid AS owner,
             array_to_json(metadata.metadata_key_id) AS metadata_keys,
             array_to_json(metadata.metadata_value) AS metadata_values,
@@ -107,7 +107,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
      * @param $result Array
      * show_id int
      * show_type_id int
-     * submitted strtotimeable string
+     * submitted unix timestamp int
      * owner int
      * metadata_keys array[int]
      * metadata_values array[string]
@@ -125,7 +125,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         //Deal with the easy fields
         $this->owner = (int) $result['owner'];
         $this->show_type = (int) $result['show_type_id'];
-        $this->submitted_time = strtotime($result['submitted']);
+        $this->submitted_time = $result['submitted'];
 
         $this->genres = json_decode($result['genres']);
         if ($this->genres === null) {

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -268,8 +268,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      * @param null   $table          No action. Used for compatibility with parent.
      * @param null   $pkey           No action. Used for compatibility with parent.
      */
-    public function setMeta($string_key, $value, $effective_from = null,
-                            $effective_to = null, $table = null, $pkey = null)
+    public function setMeta($string_key, $value, $effective_from = null, $effective_to = null, $table = null, $pkey = null)
     {
         $r = parent::setMeta($string_key, $value, $effective_from, $effective_to,
                              'schedule.timeslot_metadata', 'show_season_timeslot_id');
@@ -729,8 +728,11 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         $email .= "\r\n\r\nReason: $reason\r\n\r\nRegards\r\n" . Config::$long_name . ' Programming Team';
         self::$cache->purge();
 
-        MyRadioEmail::sendEmailToUserSet($this->getSeason()->getShow()->getCreditObjects(),
-                                         'Episode of ' . $this->getMeta('title') . ' Cancelled', $email);
+        MyRadioEmail::sendEmailToUserSet(
+            $this->getSeason()->getShow()->getCreditObjects(),
+            'Episode of ' . $this->getMeta('title') . ' Cancelled',
+            $email
+        );
 
         return true;
     }
@@ -750,10 +752,16 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         $email2 .= ' was cancelled by a presenter because ' . $reason;
         $email2 .= "\r\n\r\nIt was cancelled automatically as more than required notice was given.";
 
-        MyRadioEmail::sendEmailToUserSet($this->getSeason()->getShow()->getCreditObjects(),
-                                         'Episode of ' . $this->getMeta('title') . ' Cancelled', $email1);
-        MyRadioEmail::sendEmailToList(MyRadio_List::getByName('programming'),
-                                      'Episode of ' . $this->getMeta('title') . ' Cancelled', $email2);
+        MyRadioEmail::sendEmailToUserSet(
+            $this->getSeason()->getShow()->getCreditObjects(),
+            'Episode of ' . $this->getMeta('title') . ' Cancelled',
+            $email1
+        );
+        MyRadioEmail::sendEmailToList(
+            MyRadio_List::getByName('programming'),
+            'Episode of ' . $this->getMeta('title') . ' Cancelled',
+            $email2
+        );
 
         return true;
     }
@@ -763,8 +771,11 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         $email = $this->getMeta('title').' on '.CoreUtils::happyTime($this->getStartTime());
         $email .= ' has requested cancellation because '.$reason;
         $email .= "\r\n\r\nDue to the short notice, it has been passed to you for consideration. To cancel the timeslot, visit ";
-        $email .= URLUtils::makeURL('Scheduler', 'cancelEpisode',
-                                    ['show_season_timeslot_id' => $this->getID(), 'reason' => base64_encode($reason)]);
+        $email .= URLUtils::makeURL(
+            'Scheduler',
+            'cancelEpisode',
+            ['show_season_timeslot_id' => $this->getID(), 'reason' => base64_encode($reason)]
+        );
 
         MyRadioEmail::sendEmailToList(MyRadio_List::getByName('presenting'), 'Show Cancellation Request', $email);
 
@@ -778,8 +789,10 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      */
     private function deleteTimeslot()
     {
-        $r = self::$db->query('DELETE FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1',
-                              [$this->getID()]);
+        $r = self::$db->query(
+            'DELETE FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1',
+            [$this->getID()]
+        );
 
         $this->updateCacheObject();
 
@@ -805,12 +818,20 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                         $parts = explode('-', $op['id']);
                         if ($parts[0] === 'ManagedDB') {
                             //This is a managed item
-                            $i = NIPSWeb_TimeslotItem::createManaged($this->getID(), $parts[1],
-                                                                     $op['channel'], $op['weight']);
+                            $i = NIPSWeb_TimeslotItem::createManaged(
+                                $this->getID(),
+                                $parts[1],
+                                $op['channel'],
+                                $op['weight']
+                            );
                         } else {
                             //This is a rec database track
-                            $i = NIPSWeb_TimeslotItem::createCentral($this->getID(), $parts[1],
-                                                                     $op['channel'], $op['weight']);
+                            $i = NIPSWeb_TimeslotItem::createCentral(
+                                $this->getID(),
+                                $parts[1],
+                                $op['channel'],
+                                $op['weight']
+                            );
                         }
                     } catch (MyRadioException $e) {
                         $result[] = ['status' => false];

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -19,7 +19,7 @@ use MyRadio\SIS\SIS_Utils;
 /**
  * The Timeslot class is used to view and manupulate Timeslot within the new MyRadio Scheduler Format.
  *
- * @todo Generally the creation of bulk Timeslots is currently handled by the Season/Show classes, but this should change
+ * @todo Generally the creation of bulk Timeslots is handled by the Season/Show classes, but this should change
  *
  * @uses \Database
  * @uses \MyRadio_Show
@@ -268,9 +268,11 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      * @param null   $table          No action. Used for compatibility with parent.
      * @param null   $pkey           No action. Used for compatibility with parent.
      */
-    public function setMeta($string_key, $value, $effective_from = null, $effective_to = null, $table = null, $pkey = null)
+    public function setMeta($string_key, $value, $effective_from = null,
+                            $effective_to = null, $table = null, $pkey = null)
     {
-        $r = parent::setMeta($string_key, $value, $effective_from, $effective_to, 'schedule.timeslot_metadata', 'show_season_timeslot_id');
+        $r = parent::setMeta($string_key, $value, $effective_from, $effective_to,
+                             'schedule.timeslot_metadata', 'show_season_timeslot_id');
         $this->updateCacheObject();
 
         return $r;
@@ -294,7 +296,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             $string_keys = ['title', 'description', 'tag'];
         }
 
-        $r = parent::searchMeta($query, $string_keys, $effective_from, $effective_to, 'schedule.timeslot_metadata', 'show_season_timeslot_id');
+        $r = parent::searchMeta($query, $string_keys, $effective_from, $effective_to,
+                                'schedule.timeslot_metadata', 'show_season_timeslot_id');
 
         return self::resultSetToObjArray($r);
     }
@@ -332,8 +335,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      *
      * @param int $date If specified, only messages for timeslots since $date are counted.
      *
-     * @return array An array of 30 Timeslots that have been put through toDataSource, with the addition of a msg_count key,
-     *               referring to the number of messages sent to that show.
+     * @return array An array of 30 Timeslots that have been put through toDataSource, with the addition of a msg_count
+     *               key, referring to the number of messages sent to that show.
      */
     public static function getMostMessaged($date = 0)
     {
@@ -359,8 +362,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      *
      * @param int $date If specified, only messages for timeslots since $date are counted.
      *
-     * @return array An array of 30 Timeslots that have been put through toDataSource, with the addition of a msg_count key,
-     *               referring to the number of messages sent to that show.
+     * @return array An array of 30 Timeslots that have been put through toDataSource, with the addition of a msg_count
+     *               key, referring to the number of messages sent to that show.
      */
     public static function getMostListened($date = 0)
     {
@@ -679,13 +682,14 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      * (2) If the User is a Show Credit, and there are 48 hours or more until broadcast, they can remove it,
      *     notifying the PC
      *
-     * (3) If the User is a Show Credit, and there are less than 48 hours until broadcast, they can send a request to the
-     *     PC for removal, and it will be flagged as hidden from the Schedule - it will still count as a noshow unless (1) occurs
+     * (3) If the User is a Show Credit, and there are less than 48 hours until broadcast, they can send a request to
+     *     the PC for removal, and it will be flagged as hidden from the Schedule - it will still count as a noshow
+     *     unless (1) occurs
      *
      * @param string $reason, Why the episode was cancelled.
      *
-     * @todo Make the smarter - check if it's a programming team person, in which case just do this, if it's not
-     *       then if >48hrs away just do it but email programming, but <48hrs should hide it but tell prog to confirm reason
+     * @todo Make the smarter - check if it's a programming team person, in which case just do this, if it's not then if
+     *       >48hrs away just do it but email programming, but <48hrs should hide it but tell prog to confirm reason
      * @todo Response codes? i.e. error/db or error/403 etc
      */
     public function cancelTimeslot($reason)
@@ -719,12 +723,14 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             return false;
         }
 
-        $email = "Hi #NAME, \r\n\r\n Please note that an episode of your show, ".$this->getMeta('title').
-                ' has been cancelled by our Programming Team. The affected episode was at '.CoreUtils::happyTime($this->getStartTime());
-        $email .= "\r\n\r\nReason: $reason\r\n\r\nRegards\r\n".Config::$long_name.' Programming Team';
+        $email = "Hi #NAME, \r\n\r\n Please note that an episode of your show, " . $this->getMeta('title')
+            . ' has been cancelled by our Programming Team. The affected episode was at ';
+        $email .= CoreUtils::happyTime($this->getStartTime());
+        $email .= "\r\n\r\nReason: $reason\r\n\r\nRegards\r\n" . Config::$long_name . ' Programming Team';
         self::$cache->purge();
 
-        MyRadioEmail::sendEmailToUserSet($this->getSeason()->getShow()->getCreditObjects(), 'Episode of '.$this->getMeta('title').' Cancelled', $email);
+        MyRadioEmail::sendEmailToUserSet($this->getSeason()->getShow()->getCreditObjects(),
+                                         'Episode of ' . $this->getMeta('title') . ' Cancelled', $email);
 
         return true;
     }
@@ -736,24 +742,29 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             return false;
         }
 
-        $email1 = "Hi #NAME, \r\n\r\n You have requested that an episode of ".$this->getMeta('title').
-                ' is cancelled. The affected episode was at '.CoreUtils::happyTime($this->getStartTime());
-        $email1 .= "\r\n\r\nReason: $reason\r\n\r\nRegards\r\n".Config::$long_name.' Scheduler Robot';
+        $email1 = "Hi #NAME, \r\n\r\n You have requested that an episode of " . $this->getMeta('title').
+                ' is cancelled. The affected episode was at ' . CoreUtils::happyTime($this->getStartTime());
+        $email1 .= "\r\n\r\nReason: $reason\r\n\r\nRegards\r\n" . Config::$long_name . ' Scheduler Robot';
 
-        $email2 = $this->getMeta('title').' on '.CoreUtils::happyTime($this->getStartTime()).' was cancelled by a presenter because '.$reason;
+        $email2 = $this->getMeta('title') . ' on ' . CoreUtils::happyTime($this->getStartTime());
+        $email2 .= ' was cancelled by a presenter because ' . $reason;
         $email2 .= "\r\n\r\nIt was cancelled automatically as more than required notice was given.";
 
-        MyRadioEmail::sendEmailToUserSet($this->getSeason()->getShow()->getCreditObjects(), 'Episode of '.$this->getMeta('title').' Cancelled', $email1);
-        MyRadioEmail::sendEmailToList(MyRadio_List::getByName('programming'), 'Episode of '.$this->getMeta('title').' Cancelled', $email2);
+        MyRadioEmail::sendEmailToUserSet($this->getSeason()->getShow()->getCreditObjects(),
+                                         'Episode of ' . $this->getMeta('title') . ' Cancelled', $email1);
+        MyRadioEmail::sendEmailToList(MyRadio_List::getByName('programming'),
+                                      'Episode of ' . $this->getMeta('title') . ' Cancelled', $email2);
 
         return true;
     }
 
     private function cancelTimeslotRequest($reason)
     {
-        $email = $this->getMeta('title').' on '.CoreUtils::happyTime($this->getStartTime()).' has requested cancellation because '.$reason;
+        $email = $this->getMeta('title').' on '.CoreUtils::happyTime($this->getStartTime());
+        $email .= ' has requested cancellation because '.$reason;
         $email .= "\r\n\r\nDue to the short notice, it has been passed to you for consideration. To cancel the timeslot, visit ";
-        $email .= URLUtils::makeURL('Scheduler', 'cancelEpisode', ['show_season_timeslot_id' => $this->getID(), 'reason' => base64_encode($reason)]);
+        $email .= URLUtils::makeURL('Scheduler', 'cancelEpisode',
+                                    ['show_season_timeslot_id' => $this->getID(), 'reason' => base64_encode($reason)]);
 
         MyRadioEmail::sendEmailToList(MyRadio_List::getByName('presenting'), 'Show Cancellation Request', $email);
 
@@ -767,7 +778,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      */
     private function deleteTimeslot()
     {
-        $r = self::$db->query('DELETE FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1', [$this->getID()]);
+        $r = self::$db->query('DELETE FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1',
+                              [$this->getID()]);
 
         $this->updateCacheObject();
 
@@ -793,10 +805,12 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                         $parts = explode('-', $op['id']);
                         if ($parts[0] === 'ManagedDB') {
                             //This is a managed item
-                            $i = NIPSWeb_TimeslotItem::createManaged($this->getID(), $parts[1], $op['channel'], $op['weight']);
+                            $i = NIPSWeb_TimeslotItem::createManaged($this->getID(), $parts[1],
+                                                                     $op['channel'], $op['weight']);
                         } else {
                             //This is a rec database track
-                            $i = NIPSWeb_TimeslotItem::createCentral($this->getID(), $parts[1], $op['channel'], $op['weight']);
+                            $i = NIPSWeb_TimeslotItem::createCentral($this->getID(), $parts[1],
+                                                                     $op['channel'], $op['weight']);
                         }
                     } catch (MyRadioException $e) {
                         $result[] = ['status' => false];
@@ -993,18 +1007,18 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         $source = $_SERVER['REMOTE_ADDR'];
 
         self::$db->query(
-                'INSERT INTO sis2.messages (timeslotid, commtypeid, sender, subject, content, statusid, comm_source)
-                VALUES ($1, $2, $3, $4, $5, $6, $7)',
-                [
-                    $this->getID(),             // timeslot
-                    3,                          // commtypeid : website
-                    'MyRadio',                  // sender
-                    substr($message, 0, 144),   // subject : trancated message
-                    $prefix.$message,         // content : message with prefix
-                    $junk ? 4 : 1,              // statusid : junk or unread
-                    $source,                     // comm_source : IP
-                ]
-            );
+            'INSERT INTO sis2.messages (timeslotid, commtypeid, sender, subject, content, statusid, comm_source)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)',
+            [
+                $this->getID(),             // timeslot
+                3,                          // commtypeid : website
+                'MyRadio',                  // sender
+                substr($message, 0, 144),   // subject : trancated message
+                $prefix.$message,         // content : message with prefix
+                $junk ? 4 : 1,              // statusid : junk or unread
+                $source,                     // comm_source : IP
+            ]
+        );
 
         return $this;
     }

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -20,7 +20,10 @@ use MyRadio\iTones\iTones_Playlist;
  */
 class MyRadio_Track extends ServiceAPI
 {
-    const BASE_TRACK_SQL = 'SELECT * FROM public.rec_track';
+    const BASE_TRACK_SQL =
+        'SELECT number, title, artist, genre, clean, trackid, recordid, digitised, digitisedby,
+           duration, lastfm_verified, EXTRACT(epoch FROM length) AS length, EXTRACT(epoch FROM intro) AS intro
+         FROM public.rec_track';
 
     /**
      * The number of the Track on a Record.
@@ -150,8 +153,8 @@ class MyRadio_Track extends ServiceAPI
         $this->digitised = ($result['digitised'] == 't') ? true : false;
         $this->digitisedby = empty($result['digitisedby']) ? null : (int) $result['digitisedby'];
         $this->genre = $result['genre'];
-        $this->intro = strtotime('1970-01-01 '.$result['intro'].'+00');
-        $this->length = $result['length'];
+        $this->intro = (int) $result['intro'];
+        $this->length = (int) $result['length'];
         $this->duration = (int) $result['duration'];
         $this->number = (int) $result['intro'];
         $this->record = (int) $result['recordid'];
@@ -165,7 +168,7 @@ class MyRadio_Track extends ServiceAPI
      */
     protected static function factory($trackid)
     {
-        $sql = self::BASE_TRACK_SQL.' WHERE trackid=$1 LIMIT 1';
+        $sql = self::BASE_TRACK_SQL.' WHERE trackid=$1';
         $result = self::$db->fetchOne($sql, [$trackid]);
 
         if (empty($result)) {

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -20,7 +20,11 @@ use MyRadio\iTones\iTones_Utils;
 class MyRadio_TracklistItem extends ServiceAPI
 {
     const BASE_TRACKLISTITEM_SQL =
-        'SELECT * FROM tracklist.tracklist
+        'SELECT audiologid, source, state, timeslotid, bapsaudioid,
+         trackid, track, artist, album, trackno, length, label,
+         EXTRACT(epoch FROM timestart) AS timestart,
+         EXTRACT(epoch FROM timestop) AS timestop
+         FROM tracklist.tracklist
             LEFT JOIN tracklist.track_rec USING (audiologid)
             LEFT JOIN tracklist.track_notrec USING (audiologid)';
     private $audiologid;
@@ -41,8 +45,8 @@ class MyRadio_TracklistItem extends ServiceAPI
         $this->audiologid = (int) $result['audiologid'];
 
         $this->source = $result['source'];
-        $this->starttime = strtotime($result['timestart']);
-        $this->endtime = strtotime($result['timestop']);
+        $this->starttime = $result['timestart'];
+        $this->endtime = $result['timestop'];
         $this->state = $result['state'];
         $this->timeslot = is_numeric($result['timeslotid']) ? MyRadio_Timeslot::getInstance($result['timeslotid']) : null;
         $this->bapsaudioid = is_numeric($result['bapsaudioid']) ? (int) $result['bapsaudioid'] : null;
@@ -402,8 +406,6 @@ class MyRadio_TracklistItem extends ServiceAPI
             $return = $this->getTrack()->toDataSource($full);
         }
         $return['time'] = $this->getStartTime();
-        $return['starttime'] = date('d/m/Y H:i:s', $this->getStartTime());
-        //$return['endtime'] = $this->getEndTime();
         $return['state'] = $this->state;
         $return['audiologid'] = $this->audiologid;
 

--- a/src/Classes/ServiceAPI/MyRadio_UserTrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserTrainingStatus.php
@@ -73,8 +73,10 @@ class MyRadio_UserTrainingStatus extends MyRadio_TrainingStatus
         $this->memberpresenterstatusid = (int) $statusid;
 
         $result = self::$db->fetchOne(
-            'SELECT * FROM public.member_presenterstatus
-            WHERE memberpresenterstatusid=$1',
+            'SELECT memberid, confirmedby, revoked_by, presenterstatusid,
+               EXTRACT(epoch FROM completeddate) AS completeddate, EXTRACT(epoch FROM revokedtime) AS revokedtime
+             FROM public.member_presenterstatus
+             WHERE memberpresenterstatusid=$1',
             [$statusid]
         );
 
@@ -83,9 +85,9 @@ class MyRadio_UserTrainingStatus extends MyRadio_TrainingStatus
         }
 
         $this->user = (int) $result['memberid'];
-        $this->awarded_time = strtotime($result['completeddate']);
+        $this->awarded_time = (int) $result['completeddate'];
         $this->awarded_by = (int) $result['confirmedby'];
-        $this->revoked_time = strtotime($result['revokedtime']);
+        $this->revoked_time = (int) $result['revokedtime'];
         $this->revoked_by = (int) $result['revokedby'];
 
         parent::__construct($result['presenterstatusid']);
@@ -189,11 +191,8 @@ class MyRadio_UserTrainingStatus extends MyRadio_TrainingStatus
      *
      * @throws MyRadioException
      */
-    public static function create(
-        MyRadio_TrainingStatus $status,
-        MyRadio_User $awarded_to,
-        MyRadio_User $awarded_by = null
-    ) {
+    public static function create(MyRadio_TrainingStatus $status, MyRadio_User $awarded_to, MyRadio_User $awarded_by = null)
+    {
         //Does the User already have this?
         foreach ($awarded_to->getAllTraining(true) as $training) {
             if ($training->getID() === $status->getID()) {

--- a/src/Classes/ServiceAPI/MyRadio_UserTrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserTrainingStatus.php
@@ -73,10 +73,10 @@ class MyRadio_UserTrainingStatus extends MyRadio_TrainingStatus
         $this->memberpresenterstatusid = (int) $statusid;
 
         $result = self::$db->fetchOne(
-            'SELECT memberid, confirmedby, revoked_by, presenterstatusid,
+            'SELECT memberid, confirmedby, revokedby, presenterstatusid,
                EXTRACT(epoch FROM completeddate) AS completeddate, EXTRACT(epoch FROM revokedtime) AS revokedtime
-             FROM public.member_presenterstatus
-             WHERE memberpresenterstatusid=$1',
+            FROM public.member_presenterstatus
+            WHERE memberpresenterstatusid=$1',
             [$statusid]
         );
 

--- a/src/Controllers/Mail/archive.php
+++ b/src/Controllers/Mail/archive.php
@@ -20,7 +20,7 @@ if (!$list->isMember(MyRadio_User::getInstance()->getID())) {
 $archive = CoreUtils::dataSourceParser($list->getArchive(), false);
 
 foreach ($archive as $key => $value) {
-    $archive[$key]['timestamp'] = date('Y/m/d H:i', $archive[$key]['timestamp']);
+    $archive[$key]['timestamp'] = CoreUtils::happyTime($archive[$key]['timestamp']);
 }
 
 CoreUtils::getTemplateObject()->setTemplate('table.twig')

--- a/src/Controllers/Profile/listTrainers.php
+++ b/src/Controllers/Profile/listTrainers.php
@@ -10,7 +10,7 @@ $trainers = CoreUtils::dataSourceParser(
 );
 
 foreach ($trainers as $key => $value) {
-    $trainers[$key]['awarded_time'] = date('Y/m/d', $trainers[$key]['awarded_time']);
+    $trainers[$key]['awarded_time'] = CoreUtils::happyTime($trainers[$key]['awarded_time'], false);
 }
 
 CoreUtils::getTemplateObject()->setTemplate('table.twig')

--- a/src/Controllers/Scheduler/listTerms.php
+++ b/src/Controllers/Scheduler/listTerms.php
@@ -7,8 +7,7 @@ use \MyRadio\ServiceAPI\MyRadio_Scheduler;
 
 $terms = array_map(
     function ($x) {
-        $x['start'] = date('d/m/Y', $x['start']);
-
+        $x['start'] = CoreUtils::happyTime($x['start'], false);
         return $x;
     },
     MyRadio_Scheduler::getTerms()


### PR DESCRIPTION
Makes the API return unix timestamps everywhere, instead of varying amounts of precision and formats

Will break things.

To check:
- [ ] banner campaigns
- [ ] quote edit form
- [ ] albums
- [ ] nipsweb managed items, whatever they are
- [ ] Everything else that uses the API
- [ ] news items

Fixes #357. Probably.