### PR TITLE
check timeslot permissions for the timeslot, making owners generic

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Creditable.php
+++ b/src/Classes/ServiceAPI/MyRadio_Creditable.php
@@ -16,6 +16,7 @@ use MyRadio\ServiceAPI\MyRadio_User;
  */
 trait MyRadio_Creditable
 {
+    protected $owner;
     protected $credits = [];
     protected static $credit_names;
 
@@ -72,6 +73,24 @@ trait MyRadio_Creditable
         }
 
         return $r;
+    }
+
+    /**
+     * Checks the current user is in the credits for the creditable item
+     * @return boolean The user is an owner
+     */
+    public function isCurrentUserAnOwner()
+    {
+        if ($this->owner === $_SESSION['memberid']) {
+            return true;
+        }
+        foreach ($this->getCreditObjects() as $user) {
+            if ($user->getID() === $_SESSION['memberid']) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -25,11 +25,11 @@ class MyRadio_Season extends MyRadio_Metadata_Common
     private $show_id;
     private $term_id;
     private $submitted;
-    private $owner;
     private $timeslots;
     private $requested_times = [];
     private $requested_weeks = [];
     private $season_num;
+    protected $owner;
 
     protected function __construct($season_id)
     {
@@ -954,7 +954,7 @@ Hello,
 $times
 
   Remember that except in exceptional circumstances, you must give at least 48 hours notice for cancelling your show as part of your presenter contract. If you do not do this for two shows in one season, all other shows are forfeit and may be cancelled.
-  
+
   You can cancel a timeslot by going to: My Shows -> Seasons for Show -> Timeslots for Season, and selecting cancel for the particular time.
   ".URLUtils::makeURL('Scheduler', 'myShows').'
 

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -95,7 +95,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
             ) AS season';
 
     private $show_id;
-    private $owner;
+    protected $owner;
     protected $credits = [];
     private $genres;
     private $show_type;
@@ -584,20 +584,6 @@ class MyRadio_Show extends MyRadio_Metadata_Common
     public function getGenre()
     {
         return isset($this->genres[0]) ? $this->genres[0] : null;
-    }
-
-    public function isCurrentUserAnOwner()
-    {
-        if ($this->owner === $_SESSION['memberid']) {
-            return true;
-        }
-        foreach ($this->getCreditObjects() as $user) {
-            if ($user->getID() === $_SESSION['memberid']) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public function setShowPhoto($tmp_path)

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -30,8 +30,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
     private $start_time;
     private $duration;
     private $season_id;
-    private $owner;
     private $timeslot_num;
+    protected $owner;
     protected $credits;
 
     protected function __construct($timeslot_id)
@@ -44,15 +44,15 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         //Init Database
         self::initDB();
 
-        //Get the basic info about the season
+        //Get the basic info about the timeslot
         $result = self::$db->fetchOne(
             'SELECT show_season_timeslot_id, show_season_id, start_time, duration, memberid,
             (
                 SELECT array(
                     SELECT metadata_key_id FROM schedule.timeslot_metadata
                     WHERE show_season_timeslot_id=$1
-                    AND effective_from <= NOW()
-                    AND (effective_to IS NULL OR effective_to >= NOW())
+                    AND effective_from < (start_time + duration)
+                    AND (effective_to IS NULL OR effective_to > start_time)
                     ORDER BY effective_from, show_season_timeslot_id
                 )
             ) AS metadata_types,
@@ -60,8 +60,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                 SELECT array(
                     SELECT metadata_value FROM schedule.timeslot_metadata
                     WHERE show_season_timeslot_id=$1
-                    AND effective_from <= NOW()
-                    AND (effective_to IS NULL OR effective_to >= NOW())
+                    AND effective_from < (start_time + duration)
+                    AND (effective_to IS NULL OR effective_to > start_time)
                     ORDER BY effective_from, show_season_timeslot_id
                 )
             ) AS metadata,
@@ -81,8 +81,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                         JOIN schedule.show_season USING (show_season_id)
                         WHERE show_season_timeslot_id=$1
                     )
-                    AND effective_from <= NOW()
-                    AND (effective_to IS NULL OR effective_to >= NOW())
+                    AND effective_from < (start_time + duration)
+                    AND (effective_to IS NULL OR effective_to > start_time)
                     AND approvedid IS NOT NULL
                     ORDER BY show_credit_id
                 )
@@ -95,8 +95,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                         JOIN schedule.show_season USING (show_season_id)
                         WHERE show_season_timeslot_id=$1
                     )
-                    AND effective_from <= NOW()
-                    AND (effective_to IS NULL OR effective_to >= NOW())
+                    AND effective_from < (start_time + duration)
+                    AND (effective_to IS NULL OR effective_to > start_time)
                     AND approvedid IS NOT NULL
                     ORDER BY show_credit_id
                 )

--- a/src/Controllers/MyRadio/timeslot.php
+++ b/src/Controllers/MyRadio/timeslot.php
@@ -21,7 +21,7 @@ function setupTimeslot($timeslot)
     }
 
     //Can the user access this timeslot?
-    if (!($timeslot->getSeason()->getShow()->isCurrentUserAnOwner() || AuthUtils::hasPermission(AUTH_EDITSHOWS))) {
+    if (!($timeslot->isCurrentUserAnOwner() || AuthUtils::hasPermission(AUTH_EDITSHOWS))) {
         $message = "You don't have permission to view this show";
         require_once 'Controllers/Errors/403.php';
     } else {


### PR DESCRIPTION
This also prevents access to non credited timeslots within a show, though they will still be visible in the list.