### PR TITLE
Add ability to leave demos

### DIFF
--- a/src/Controllers/Scheduler/leaveDemo.php
+++ b/src/Controllers/Scheduler/leaveDemo.php
@@ -1,0 +1,8 @@
+<?php
+
+use \MyRadio\MyRadio\URLUtils;
+use \MyRadio\ServiceAPI\MyRadio_Demo;
+
+MyRadio_Demo::leave($_REQUEST['demoid']);
+URLUtils::redirect($module, 'listDemos', ['msg' => 3]); // 3 means left... see listDemos.php
+


### PR DESCRIPTION
Add ability to leave demos.
This involved reshuffling some logic from MyRadio_Demo to the controller, so that the link could change from join to leave as appropriate. Bonus - no join link is shown if the demo is full.
Resolves #503.