### PR TITLE
Show eduroam/local_alias/memberID in members drop-downs.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -786,7 +786,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
      * @return array A 2D Array where every value of the first dimension is an Array as follows:<br>
      *               memberid: The unique id of the User<br>
      *               fname: The actual first name of the User<br>
-     *               sname: The actual last name of the User
+     *               sname: The actual last name of the User<br>
+     *               eduroam: The actual eduroam account of the User
      */
     public static function findByName($name, $limit = -1)
     {
@@ -798,14 +799,14 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $names = explode(' ', $name);
         if (isset($names[1])) {
             return self::$db->fetchAll(
-                'SELECT memberid, fname, sname FROM member
+                'SELECT memberid, fname, sname, eduroam, local_alias FROM member
                 WHERE fname ILIKE $1 || \'%\' AND sname ILIKE $2 || \'%\'
                 ORDER BY sname, fname LIMIT $3',
                 [$names[0], $names[1], $limit]
             );
         } else {
             return self::$db->fetchAll(
-                'SELECT memberid, fname, sname FROM member
+                'SELECT memberid, fname, sname, eduroam, local_alias FROM member
                 WHERE fname ILIKE $1 || \'%\' OR sname ILIKE $1 || \'%\'
                 ORDER BY sname, fname LIMIT $2',
                 [$name, $limit]

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -787,7 +787,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
      *               memberid: The unique id of the User<br>
      *               fname: The actual first name of the User<br>
      *               sname: The actual last name of the User<br>
-     *               eduroam: The actual eduroam account of the User
+     *               eduroam: The actual eduroam account of the User<br>
+     *               local_alias: The actual local alias (THISPART@emailaddr) for the user
      */
     public static function findByName($name, $limit = -1)
     {

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -37,29 +37,22 @@ window.MyRadioForm = {
      */
         var memberFields = $('fieldset.myradiofrm input.member-autocomplete:not(.tt-hint):not(.tt-input)');
         if (memberFields.length > 0) {
-            var memberLookup = new Bloodhound(
-                
+            var memberLookup = new Bloodhound(            
                 {
                     datumTokenizer: Bloodhound.tokenizers.whitespace,
                     queryTokenizer: Bloodhound.tokenizers.whitespace,
-                    limit: 50,
+                    limit: 25,
                     dupDetector: function (remote, local) {
                         return local.memberid == remote.memberid;
                     },
                     prefetch: {
                         url: myradio.makeURL('MyRadio', 'a-findmember', {term: null, limit: 500})
                     },
-                    remote: {
-                        url: myradio.makeURL('MyRadio', 'a-findmember', {limit: 25, term: ''}) + '%QUERY',//Seperated out otherwise % gets urlescaped
-                        ajax: {
-                            type: 'GET',
-                            dataType: 'json',
-                        }
-                    } 
+                    remote: myradio.makeURL('MyRadio', 'a-findmember', {limit: 25, term: ''}) + '%QUERY' //Seperated out otherwise % gets urlescaped
                 }
             );
             memberLookup.initialize();
-            
+       
             memberFields.each(
                 function () {
                     var idField =  $('#' + $(this).attr('id').replace(/-ui$/, ''));
@@ -73,7 +66,6 @@ window.MyRadioForm = {
                         },
                         {
                             displayKey: function (i) {
-                                alert(JSON.stringify(i))
                                 return i.fname + ' ' + i.sname;
                             },
                             source: memberLookup.ttAdapter(),
@@ -85,9 +77,9 @@ window.MyRadioForm = {
                                     $('input:focus').parent().children('.tt-dropdown-menu').removeClass('hidden');
                                     var identity
                                     if (i.eduroam != null) {
-                                        identity = '(' + i.eduroam + ')';
+                                        identity = '(Eduroam:' + i.eduroam + ')';
                                     } else if (i.local_alias != null) {
-                                        identity = '(' + i.local_alias + ')';
+                                        identity = '(Alias: ' + i.local_alias + ')';
                                     } else {
                                         identity = '(#' + i.memberid + ')';
                                     }

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -40,8 +40,11 @@ window.MyRadioForm = {
             var memberLookup = new Bloodhound(
                 {
                     datumTokenizer: function (i) {
-                        return Bloodhound.tokenizers.whitespace(i.fname)
-                        .concat(Bloodhound.tokenizers.whitespace(i.sname));
+                        var strmemberID = Bloodhound.tokenizers.whitespace(i.memberid);
+                        var strfname = Bloodhound.tokenizers.whitespace(i.fname);
+                        var strsname = Bloodhound.tokenizers.whitespace(i.sname);
+                        var streduroam = Bloodhound.tokenizers.whitespace(i.eduroam);
+                        return strmemberID.concat(strfname).concat(strsname).concat(streduroam);
                     },
                     queryTokenizer: Bloodhound.tokenizers.whitespace,
                     limit: 25,
@@ -78,7 +81,14 @@ window.MyRadioForm = {
                                     //Fix typeahead not showing after hiding
                                     //TODO: Report this @ https://github.com/twitter/typeahead.js/
                                     $('input:focus').parent().children('.tt-dropdown-menu').removeClass('hidden');
-                                    return '<p>' + i.fname + ' ' + i.sname + '</p>';
+                                    if (i.eduroam != null) {
+                                        var identity = '(' + i.eduroam + ')';
+                                    } else if (i.local_alias != null) {
+                                        var identity = '(' + i.local_alias + ')';
+                                    } else {
+                                        var identity = '(#' + i.memberid + ')';
+                                    }
+                                    return '<p>' + i.fname + ' ' + i.sname + ' ' + identity + '</p>';
                                 }
                             }
                         }

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -38,27 +38,28 @@ window.MyRadioForm = {
         var memberFields = $('fieldset.myradiofrm input.member-autocomplete:not(.tt-hint):not(.tt-input)');
         if (memberFields.length > 0) {
             var memberLookup = new Bloodhound(
+                
                 {
-                    datumTokenizer: function (i) {
-                        var strmemberID = Bloodhound.tokenizers.whitespace(i.memberid);
-                        var strfname = Bloodhound.tokenizers.whitespace(i.fname);
-                        var strsname = Bloodhound.tokenizers.whitespace(i.sname);
-                        var streduroam = Bloodhound.tokenizers.whitespace(i.eduroam);
-                        return strmemberID.concat(strfname).concat(strsname).concat(streduroam);
-                    },
+                    datumTokenizer: Bloodhound.tokenizers.whitespace,
                     queryTokenizer: Bloodhound.tokenizers.whitespace,
-                    limit: 25,
+                    limit: 50,
                     dupDetector: function (remote, local) {
                         return local.memberid == remote.memberid;
                     },
                     prefetch: {
                         url: myradio.makeURL('MyRadio', 'a-findmember', {term: null, limit: 500})
                     },
-                    remote: myradio.makeURL('MyRadio', 'a-findmember', {limit: 25, term: ''}) + '%QUERY' //Seperated out otherwise % gets urlescaped
+                    remote: {
+                        url: myradio.makeURL('MyRadio', 'a-findmember', {limit: 25, term: ''}) + '%QUERY',//Seperated out otherwise % gets urlescaped
+                        ajax: {
+                            type: 'GET',
+                            dataType: 'json',
+                        }
+                    } 
                 }
             );
             memberLookup.initialize();
-
+            
             memberFields.each(
                 function () {
                     var idField =  $('#' + $(this).attr('id').replace(/-ui$/, ''));
@@ -72,6 +73,7 @@ window.MyRadioForm = {
                         },
                         {
                             displayKey: function (i) {
+                                alert(JSON.stringify(i))
                                 return i.fname + ' ' + i.sname;
                             },
                             source: memberLookup.ttAdapter(),
@@ -81,12 +83,13 @@ window.MyRadioForm = {
                                     //Fix typeahead not showing after hiding
                                     //TODO: Report this @ https://github.com/twitter/typeahead.js/
                                     $('input:focus').parent().children('.tt-dropdown-menu').removeClass('hidden');
+                                    var identity
                                     if (i.eduroam != null) {
-                                        var identity = '(' + i.eduroam + ')';
+                                        identity = '(' + i.eduroam + ')';
                                     } else if (i.local_alias != null) {
-                                        var identity = '(' + i.local_alias + ')';
+                                        identity = '(' + i.local_alias + ')';
                                     } else {
-                                        var identity = '(#' + i.memberid + ')';
+                                        identity = '(#' + i.memberid + ')';
                                     }
                                     return '<p>' + i.fname + ' ' + i.sname + ' ' + identity + '</p>';
                                 }

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -75,7 +75,7 @@ window.MyRadioForm = {
                                     //Fix typeahead not showing after hiding
                                     //TODO: Report this @ https://github.com/twitter/typeahead.js/
                                     $('input:focus').parent().children('.tt-dropdown-menu').removeClass('hidden');
-                                    var identity
+                                    var identity = '';
                                     if (i.eduroam != null) {
                                         identity = '(Eduroam:' + i.eduroam + ')';
                                     } else if (i.local_alias != null) {

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -37,7 +37,7 @@ window.MyRadioForm = {
      */
         var memberFields = $('fieldset.myradiofrm input.member-autocomplete:not(.tt-hint):not(.tt-input)');
         if (memberFields.length > 0) {
-            var memberLookup = new Bloodhound(            
+            var memberLookup = new Bloodhound(
                 {
                     datumTokenizer: Bloodhound.tokenizers.whitespace,
                     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -52,7 +52,7 @@ window.MyRadioForm = {
                 }
             );
             memberLookup.initialize();
-       
+
             memberFields.each(
                 function () {
                     var idField =  $('#' + $(this).attr('id').replace(/-ui$/, ''));


### PR DESCRIPTION
Fixes: UniversityRadioYork/Issues#56, #592 

Looks like the issues I was having before was due to caching, the code is working as it should now (after ignoring it for ages). It chooses eduroam first, followed by localAlias, followed by memberID as least preferred.  👍 