### PR TITLE
A few bug fixes and niceties I found trying to setup a local MyRadio

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Username: myradio
 Password: myradio
 
 Quickstart
-----------
+==========
 Install Apache2, PHP, Composer and PostgreSQL on your prefered *nix distro.
 Or Windows, if you're into that. MyRadio has been tested with Ubuntu and
 FreeBSD.
@@ -65,6 +65,24 @@ psql
 CREATE USER myradio WITH password '[A_STRONG_PASSWORD]';
 CREATE DATABASE myradio WITH OWNER=myradio;
 ```
+
+Next steps
+==========
+Once you've got through the setup wizard, the next thing that's most useful to
+you is most likely creating a show.
+
+To do this, you first need to:
+- Create a Term (Show Scheduler -> Manage Terms)
+- Create a Show (List My Shows -> Create a Show)
+- Apply for a Season of your new Show (List My Shows -> New Season)
+- Schedule the Season (Shows Scheduler)
+
+A note on Seasons and Terms
+---------------------------
+MyRadio splits Shows into "Seasons". Any Season is applied to in relation to a
+"Term", which is a 10-week space of time. This is because The University of
+York has 10 week terms, if you didn't know.
+
 
 MyRadio uses GitHub Flow as a development workflow:
 https://guides.github.com/overviews/flow/

--- a/schema/data-apiauth.json
+++ b/schema/data-apiauth.json
@@ -1,3 +1,7 @@
 [
+    ["\\MyRadio\\ServiceAPI\\MyRadio_Timeslot", "get9DaySchedule", null],
+    ["\\MyRadio\\ServiceAPI\\MyRadio_Timeslot", "getCreditsNames", null],
+    ["\\MyRadio\\ServiceAPI\\MyRadio_Timeslot", "getCurrentAndNext", null],
+    ["\\MyRadio\\ServiceAPI\\MyRadio_Timeslot", "getWeekSchedule", null],
     ["\\MyRadio\\ServiceAPI\\MyRadio_Track", "setIntro", "AUTH_USENIPSWEB"]
 ]

--- a/src/Classes/Config.php
+++ b/src/Classes/Config.php
@@ -93,7 +93,7 @@ final class Config
      *
      * @var bool
      */
-    public static $rewrite_url = false;
+    public static $rewrite_url = true;
 
     /**
      * Whether to enable the Caching system

--- a/src/Classes/ServiceAPI/MyRadio_Scheduler.php
+++ b/src/Classes/ServiceAPI/MyRadio_Scheduler.php
@@ -340,7 +340,7 @@ class MyRadio_Scheduler extends MyRadio_Metadata_Common
                 'descr',
                 MyRadioFormField::TYPE_TEXT,
                 [
-                    'explanation' => 'Name the term. Try and make it unique.',
+                    'explanation' => 'Name the term. A value of "Autumn" denotes that this term represents the start of a new membership year.',
                     'label' => 'Term description',
                     'options' => ['maxlength' => 10],
                 ]

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -858,6 +858,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
             'credits' => array_map(
                 function ($x) {
                     $x['User'] = $x['User']->toDataSource();
+                    $x['type_name'] = $this->getCreditName($x['type']);
 
                     return $x;
                 },

--- a/src/Menus/Scheduler.json
+++ b/src/Menus/Scheduler.json
@@ -24,12 +24,17 @@
             {
                 "title": "Create a Show",
                 "url": "module=Scheduler,action=editShow",
-                "description": "Create a new show on the URY Scheduler"
+                "description": "Create a new show on the URY Scheduler."
             },
             {
                 "title": "Add Training Session",
                 "url": "module=Scheduler,action=createDemo",
-                "description": "Add a training slot that newbies can sign up to"
+                "description": "Add a training slot that newbies can sign up to."
+            },
+            {
+                "title": "Manage Terms",
+                "url": "module=Scheduler,action=listTerms",
+                "description": "Seasons are applied to in relation to Terms. Manage Terms here."
             }
         ]
 }

--- a/src/Templates/Scheduler/allocate.twig
+++ b/src/Templates/Scheduler/allocate.twig
@@ -1,13 +1,13 @@
 {% extends 'form.twig' %}
 
 {% block stripecontent %}
-<p>You are allocating Timeslots for a Season of <strong>{{frm_custom.name}}</strong> in the current term.</p>
+<p>You are allocating Timeslots for a Season of <strong>{{frm_custom.title}}</strong> in the current term.</p>
 <div class="well">
 {{frm_custom.description|raw}}
 </div>
 <ul id="allocate_credits">
 {% for credit in frm_custom.credits %}
-<li>{{credit.type_name}}: {{credit.name}}</li>
+<li>{{credit.type_name}}: {{credit.User.fname}} {{credit.User.sname}}</li>
 {% endfor %}
 </ul>
 {{ parent() }}


### PR DESCRIPTION
- Update readme as a hint for the steps needed to make a show (which is really needed to do anything with a new MyRadio)
- Add some missing default API permission entries, without which various bits of MyRadio just error at you
- Fix the allocate season page by using the new location of a user's name and adding back the type_name field for credit dataSource objects
- Add missing Manage Terms link to the Scheduler menu
- Default to using prettier URLs for prettyness