### PR TITLE
Add the ability to set the output device, just like a real BAPS.

### DIFF
--- a/sample_configs/bootstrap.sh
+++ b/sample_configs/bootstrap.sh
@@ -70,4 +70,4 @@ service apache2 start
 
 # Somewhere to store audio uploads
 mkdir -p /music/records
-chown apache2:apache2 /music/records
+chown www-data:www-data /music/records

--- a/sample_configs/bootstrap.sh
+++ b/sample_configs/bootstrap.sh
@@ -17,7 +17,7 @@ apt-get install -y apache2 \
 	php-pear \
 	php5-memcached \
 	openssl \
-  libav-tools
+	libav-tools
 a2enmod ssl
 a2enmod rewrite
 service apache2 stop
@@ -52,12 +52,12 @@ emailAddress=someone@example.com
 "
 openssl genrsa -des3 -out /etc/apache2/myradio.key -passout env:PASSPHRASE 2048
 openssl req \
-  -new \
-  -batch \
-  -subj "$(echo -n "$subj" | tr "\n" "/")" \
-  -key /etc/apache2/myradio.key \
-  -out /etc/apache2/myradio.csr \
-  -passin env:PASSPHRASE
+	-new \
+	-batch \
+	-subj "$(echo -n "$subj" | tr "\n" "/")" \
+	-key /etc/apache2/myradio.key \
+	-out /etc/apache2/myradio.csr \
+	-passin env:PASSPHRASE
 openssl rsa -in /etc/apache2/myradio.key -out /etc/apache2/myradio.key -passin env:PASSPHRASE
 openssl x509 -req -days 3650 -in /etc/apache2/myradio.csr -signkey /etc/apache2/myradio.key -out /etc/apache2/myradio.crt
 

--- a/sample_configs/bootstrap.sh
+++ b/sample_configs/bootstrap.sh
@@ -16,7 +16,8 @@ apt-get install -y apache2 \
 	php5-dev \
 	php-pear \
 	php5-memcached \
-	openssl
+	openssl \
+  libav-tools
 a2enmod ssl
 a2enmod rewrite
 service apache2 stop
@@ -66,3 +67,7 @@ su - postgres -c "cat /vagrant/sample_configs/postgres.sql | psql"
 
 # Start httpd back up
 service apache2 start
+
+# Somewhere to store audio uploads
+mkdir -p /music/records
+chown apache2:apache2 /music/records

--- a/sample_configs/bootstrap.sh
+++ b/sample_configs/bootstrap.sh
@@ -69,5 +69,8 @@ su - postgres -c "cat /vagrant/sample_configs/postgres.sql | psql"
 service apache2 start
 
 # Somewhere to store audio uploads
-mkdir -p /music/records
-chown www-data:www-data /music/records
+music_dirs=( "records" "membersmusic" "beds" "jingles" )
+for i in "${music_dirs[@]}"; do
+	mkdir -p /music/$i
+	chown www-data:www-data /music/$i
+done

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -143,6 +143,10 @@ div.baps-channel {
   user-select: none;
 }
 
+div.baps-channel a {
+  color: #FFF;
+}
+
 ul.baps-channel li {
   list-style: none;
   cursor: pointer;

--- a/src/Public/js/nipsweb.channelconfig.js
+++ b/src/Public/js/nipsweb.channelconfig.js
@@ -65,6 +65,16 @@ var ChannelConfigurator = function(player) {
                 }
             }
 
+            // Set the current value, if there is one
+            try {
+                if (localStorage.hasOwnProperty('nipsWebDeviceMapping')) {
+                    var storedValue = JSON.parse(localStorage.nipsWebDeviceMapping)[player.nipswebId];
+                    if (storedValue) {
+                        select.value = storedValue;
+                    }
+                }
+            } catch (e) {console.error('Local Storage is being mean.', e);}
+
             select.addEventListener('change', function() {
                 var sink = this.value;
                 player.setSinkId(sink)

--- a/src/Public/js/nipsweb.channelconfig.js
+++ b/src/Public/js/nipsweb.channelconfig.js
@@ -1,0 +1,120 @@
+var ChannelConfigurator = function(player) {
+
+    var getOrUpdateStoredDeviceMappings = function(devices) {
+        var map = [];
+        var unmapped = [];
+        var mapped;
+
+        var storedDevices = [];
+
+        try {
+            if (localStorage && localStorage.hasOwnProperty('nipsWebKnownDevices')) {
+                storedDevices = localStorage.nipsWebKnownDevices;
+            }
+        } catch (e) {console.error('Local Storage is being mean.', e);}
+
+        for (var i = 0; i < devices.length; i++) {
+            if (devices[i].kind === 'audiooutput' && devices[i].groupId !== 'communications') {
+                mapped = false;
+                for (var j = 0; j < storedDevices.length; j++) {
+                    if (devices[i].groupId == storedDevices[j]) {
+                        // We've previously seen this device. Use the previous number.
+                        mapped = true;
+                        map[storedDevices[j]] = devices[i].groupId;
+                        break;
+                    }
+                }
+                if (!mapped) {
+                    // Ooh, this is a new device
+                    unmapped.push(devices[i]);
+                }
+            }
+        }
+
+        // For each unmapped device, shove it in at the end of the map.
+        // Should we actually put it in the first free gap, perhaps?
+        for (i = 0; i < unmapped.length; i++) {
+            map.push(unmapped[i].groupId);
+        }
+
+        // And update localStorage
+        try {
+            localStorage.nipsWebKnownDevices = map;
+        } catch (e) {console.error('Local Storage is being mean.', e);}
+
+        return map;
+    };
+
+    var getOnDevicesReady = function(player, select) {
+        return function(devices) {
+            select.childNodes[0].remove();
+            var map = getOrUpdateStoredDeviceMappings(devices);
+            var option = document.createElement('option');
+
+            option.textContent = 'Default';
+            option.value = 'default';
+            select.appendChild(option);
+
+            for (var i = 0; i < map.length; i++) {
+                // Skip missing numbers (i.e. removed devices)
+                if (map[i].length) {
+                    option = document.createElement('option');
+                    option.textContent = 'Output device #' + (i+1) + ' (' + map[i].substring(0, 8) + ')';
+                    option.value = map[i];
+                    select.appendChild(option);
+                }
+            }
+
+            select.addEventListener('change', function() {
+                var sink = this.value;
+                player.setSinkId(sink)
+                    .then(function() {
+                        console.log('Changed output successfully', player, sink);
+                        try {
+                            var nwdm = {};
+                            if (localStorage.hasOwnProperty('nipsWebDeviceMapping')) {
+                                nwdm = JSON.parse(localStorage.nipsWebDeviceMapping);
+                            }
+                            nwdm[player.nipswebId] = sink;
+                            localStorage.nipsWebDeviceMapping = JSON.stringify(nwdm);
+                        } catch (e) {console.error('Local Storage is being mean.', e);}
+                    })
+                    .catch(function(error) {
+                        console.error('Failed to change output', player, sink, error);
+                        select.value = 'default';
+                    });
+            });
+        }
+    };
+
+    var getOnDevicesError = function(select) {
+        select.childNodes[0].textContent = 'Error loading devices. Sorry :-(';
+    }
+
+    var construct = function(player) {
+        var container = document.createElement('div');
+        var header = document.createElement('h4');
+        var desc = document.createElement('p');
+        var select = document.createElement('select');
+        var loadingOption = document.createElement('option');
+        var dialog = myradio.createDialog('Configure Channel', container);
+        header.textContent = 'Output device'
+        desc.textContent = 'This feature, currently only available in Chrome, enables the mapping of channels to different actual outputs. This potentially allows the use of Show Planner as an actual BAPS replacement.';
+        loadingOption.disabled = true;
+        loadingOption.selected = true;
+        loadingOption.textContent = 'Asking nicely for devices (you may need to allow access to you microphone, but we won\'t use it, that\'s just how it\'s worded...)';
+
+        container.appendChild(header);
+        container.appendChild(desc);
+        container.appendChild(select);
+        select.appendChild(loadingOption);
+
+        navigator.mediaDevices.getUserMedia({audio: true}).then(function() {
+            navigator.mediaDevices.enumerateDevices()
+                .then(getOnDevicesReady(player, select))
+                .catch(getOnDevicesError(select));
+        });
+    };
+
+    construct(player);
+};

--- a/src/Public/js/nipsweb.librarypane.js
+++ b/src/Public/js/nipsweb.librarypane.js
@@ -221,7 +221,7 @@ $(document).ready(
         $('#a-manage-library').click(
             function () {
                 var url = $(this).children('a').attr('href');
-                var dialog = myradio.createDialog('Manage Library', '<iframe src="' + url + '" width="580" height="500" frameborder="0"></iframe></div>');
+                var dialog = myradio.createDialog('Manage Library', '<iframe src="' + url + '" width="580" height="500" frameborder="0"></iframe>');
                 return false;
             }
         );

--- a/src/Public/js/nipsweb.player.js
+++ b/src/Public/js/nipsweb.player.js
@@ -1077,7 +1077,7 @@ var playoutSlider = function (e) {
         }
 
         slider.style.width = result + 'px';
-        return Math.round(result / getPixelsPerSecond() * 100) / 100;
+        return Math.Max(0, Math.round(result / getPixelsPerSecond() * 100) / 100);
     };
 
     var getXOffset = function (e) {

--- a/src/Templates/NIPSWeb/main.twig
+++ b/src/Templates/NIPSWeb/main.twig
@@ -45,7 +45,7 @@
       {% set channels = [1, 2, 3, 'res'] %}
       {% for channel in channels %}
         <div class='box col-xs-3 baps-channel channel-footer{% if channel == 'res' %} library-footer{% endif %}'>
-          <a href='javascript:' id='baps-channel-{{channel}}-name'>{% if channel == 'res' %}Library{% else %}Channel {{channel}}{% endif %}</a>&nbsp
+          <a href='javascript:' id='baps-channel-{{channel}}-name'>{% if channel == 'res' %}Library{% else %}Channel {{channel}}{% endif %}</a>&nbsp;
           <span id='baps-channel-{{channel}}-total' title="Total time of all tracks in this channel">(00:00)</span>
           <br>
           <div class="btn-group">

--- a/src/Templates/NIPSWeb/main.twig
+++ b/src/Templates/NIPSWeb/main.twig
@@ -44,7 +44,8 @@
     <div id="baps-channelaction-container"  class="clearfix">
       {% set channels = [1, 2, 3, 'res'] %}
       {% for channel in channels %}
-        <div class='box col-xs-3 baps-channel channel-footer {% if channel == 'res' %} library-footer'>Library{% else %}'>Channel {{channel}}{% endif %}
+        <div class='box col-xs-3 baps-channel channel-footer{% if channel == 'res' %} library-footer{% endif %}'>
+          <a href='javascript:' id='baps-channel-{{channel}}-name'>{% if channel == 'res' %}Library{% else %}Channel {{channel}}{% endif %}</a>&nbsp
           <span id='baps-channel-{{channel}}-total' title="Total time of all tracks in this channel">(00:00)</span>
           <br>
           <div class="btn-group">
@@ -68,6 +69,7 @@
 {{ parent() }}
 <script type="text/javascript" src="{{baseurl}}js/vendor/typeahead.bundle.min.js"></script>
 <script type="text/javascript" src="{{baseurl}}js/ul-sort.js"></script>
+<script type="text/javascript" src="{{baseurl}}js/nipsweb.channelconfig.js"></script>
 <script type="text/javascript" src="{{baseurl}}js/nipsweb.player.js"></script>
 <script type="text/javascript" src="{{baseurl}}js/nipsweb.librarypane.js"></script>
 <script type="text/javascript" src="{{baseurl}}js/nipsweb.init.js"></script>


### PR DESCRIPTION
I should probably add a description for this one!

This PR (along with a couple small Vagrant fixes), makes uses of the draft Audio Output Devices API, which has been available in Chrome for about a year now.

It enables you to configure a HTMLMediaElement's hardware output device, although with the caveat that the journey in for requesting access in the browser actually asks if you want to grant Microphone access, as the permission for Input/Output is the same.

By clicking on the channel name (e.g. "Channel 1") at the bottom of a channel, a new Channel Settings dialog appears, which currently only has this one new setting.

When this dialog is first opened, Chrome will ask the user for access to the microphone, and if granted the dropdown box shows an enumeration of available hardware output devices. These are numbered, and the mapping from number -> guid is persisted in local storage to prevent numbers flipping around from device connection/disconnection or browsers not having a deterministic API.

When the value of the input box is changed, the output of the channel is immediately changed, and this output mapping becomes stored in local storage too. Subsequent visits to Show Planner will reload the local storage configuration, re-request Microphone access if necessary, therefore persisting this configuration.