### PR TITLE
Remove LastFm, implement auto ID3 tagging and improve UI of Track Uploader.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -626,31 +626,29 @@ class MyRadio_Track extends ServiceAPI
         // File quality checks
         if ($fileInfo['audio']['bitrate'] < 192000) {
             return ['status' => 'FAIL', 'message' => 'Bitrate is below 192kbps', 'fileid' => $filename, 'bitrate' => $fileInfo['audio']['bitrate']];
-        } else if (strpos($fileInfo['audio']['channelmode'], 'stereo') === false) {
+        }
+        if (strpos($fileInfo['audio']['channelmode'], 'stereo') === false) {
             return ['status' => 'FAIL', 'message' => 'Item is not stereo', 'fileid' => $filename, 'channelmode' => $fileInfo['audio']['channelmode']];
-        } else {
-            $analysis['status'] = 'INFO';
-            $analysis['message'] = 'Currently editing track information for';
-            $analysis['submittable'] = True;
-            $analysis['fileid'] = $filename;
-            $analysis['analysis']['title'] = $fileInfo['comments_html']['title'];
-            $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'];
-            $analysis['analysis']['album'] = $fileInfo['comments_html']['album'];
+        }
+
+        $analysis['status'] = 'INFO';
+        $analysis['message'] = 'Currently editing track information for';
+        $analysis['submittable'] = True;
+        $analysis['fileid'] = $filename;
+        $analysis['analysis']['title'] = $fileInfo['comments_html']['title'];
+        $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'];
+        $analysis['analysis']['album'] = $fileInfo['comments_html']['album'];
             
            
-            //Remove total tracks in album from the track_number tag.
-            $trackNo = explode("/", $fileInfo['comments_html']['track_number'][0], 2)[0];
-            $analysis['analysis']['position'] = (string)$trackNo;
+        //Remove total tracks in album from the track_number tag.
+        $trackNo = explode("/", $fileInfo['comments_html']['track_number'][0], 2)[0];
+        $analysis['analysis']['position'] = (string)$trackNo;
 
-            $trackName = implode("", $fileInfo['comments_html']['title']);
+        $trackName = implode("", $fileInfo['comments_html']['title']);
            
-            if (stripos($trackName, 'explicit') == true) {
-                $analysis['analysis']['explicit'] = true;
-            } else {
-                $analysis['analysis']['explicit'] = false;
-            }
-            return $analysis;
-        }
+        $analysis['analysis']['explicit'] = !!stripos($trackName, 'explicit');
+
+        return $analysis;
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -636,9 +636,14 @@ class MyRadio_Track extends ServiceAPI
             $analysis['analysis']['title'] = $fileInfo['comments_html']['title'];
             $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'];
             $analysis['analysis']['album'] = $fileInfo['comments_html']['album'];
-            $analysis['analysis']['position'] = $fileInfo['comments_html']['track_number'][0];
+            
+           
+            //Remove total tracks in album from the track_number tag.
+            $trackNo = explode("/", $fileInfo['comments_html']['track_number'][0], 2)[0];
+            $analysis['analysis']['position'] = (string)$trackNo;
 
             $trackName = implode("", $fileInfo['comments_html']['title']);
+           
             if (stripos($trackName, 'explicit') == true) {
                 $analysis['analysis']['explicit'] = true;
             } else {

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -625,36 +625,26 @@ class MyRadio_Track extends ServiceAPI
 
         // File quality checks
         if ($fileInfo['audio']['bitrate'] < 192000) {
-            return ['status' => 'FAIL', 'error' => 'Bitrate is below 192kbps.', 'fileid' => $filename, 'bitrate' => $fileInfo['audio']['bitrate']];
-        }
-        if (strpos($fileInfo['audio']['channelmode'], 'stereo') === false) {
-            return ['status' => 'FAIL', 'error' => 'Item is not stereo.', 'fileid' => $filename, 'channelmode' => $fileInfo['audio']['channelmode']];
-        }
-        if (strpos($fileInfo['audio']['channelmode'], 'stereo') === false) {
-            return ['status' => 'FAIL', 'error' => 'Item is not stereo.', 'fileid' => $filename, 'channelmode' => $fileInfo['audio']['channelmode']];
-        }
-
-        $analysis = self::identifyUploadedTrack(Config::$audio_upload_tmp_dir.'/'.$filename);
-        if (isset($analysis['status'])) {
-            //If song can't be found in Last FM'
-            $analysis['error'] = $analysis['error'] . ' Track metadata will be automatically filled-in below if embeded within the file.';
+            return ['status' => 'FAIL', 'message' => 'Bitrate is below 192kbps', 'fileid' => $filename, 'bitrate' => $fileInfo['audio']['bitrate']];
+        } else if (strpos($fileInfo['audio']['channelmode'], 'stereo') === false) {
+            return ['status' => 'FAIL', 'message' => 'Item is not stereo', 'fileid' => $filename, 'channelmode' => $fileInfo['audio']['channelmode']];
+        } else {
+            $analysis['status'] = 'INFO';
+            $analysis['message'] = 'Currently editing track information for';
+            $analysis['submittable'] = True;
             $analysis['fileid'] = $filename;
             $analysis['analysis']['title'] = $fileInfo['comments_html']['title'];
-            $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'][0];
+            $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'];
             $analysis['analysis']['album'] = $fileInfo['comments_html']['album'];
             $analysis['analysis']['position'] = $fileInfo['comments_html']['track_number'];
-            if (strpos($fileInfo['comments_html']['title'], 'explicit') == true) {
+
+            $trackName = implode("", $fileInfo['comments_html']['title']);
+            if (stripos($trackName, 'explicit') == true) {
                 $analysis['analysis']['explicit'] = true;
             } else {
                 $analysis['analysis']['explicit'] = false;
             }
             return $analysis;
-        } else {
-            return [
-                'fileid' => $filename,
-                'status' => 'OK',
-                'analysis' => $analysis,
-            ];
         }
     }
 

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -620,7 +620,7 @@ class MyRadio_Track extends ServiceAPI
         $getID3 = new \getID3();
         $fileInfo = $getID3->analyze(Config::$audio_upload_tmp_dir.'/'.$filename);
         $getID3_lib = new \getID3_lib();
-        $getID3_lib->CopyTagsToComments($fileInfo);       
+        $getID3_lib->CopyTagsToComments($fileInfo);
 
         // File quality checks
         if ($fileInfo['audio']['bitrate'] < 192000) {
@@ -697,6 +697,7 @@ class MyRadio_Track extends ServiceAPI
             return $tracks;
         }
     }
+    
     /**
       * Pay special attention to the tri-state value of explicit. False and null are different things.
     */

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -619,6 +619,8 @@ class MyRadio_Track extends ServiceAPI
 
         $getID3 = new \getID3();
         $fileInfo = $getID3->analyze(Config::$audio_upload_tmp_dir.'/'.$filename);
+        $getID3_lib = new \getID3_lib();
+        $getID3_lib->CopyTagsToComments($fileInfo);
         
 
         // File quality checks
@@ -637,11 +639,11 @@ class MyRadio_Track extends ServiceAPI
             //If song can't be found in Last FM'
             $analysis['error'] = $analysis['error'] . ' Track metadata will be automatically filled-in below if embeded within the file.';
             $analysis['fileid'] = $filename;
-            $analysis['analysis']['title'] = $fileInfo['tags_html']['id3v1']['title'];
-            $analysis['analysis']['artist'] = $fileInfo['tags_html']['id3v1']['artist'][0];
-            $analysis['analysis']['album'] = $fileInfo['tags_html']['id3v1']['album'];
-            $analysis['analysis']['position'] = $fileInfo['tags_html']['id3v2']['track_number'];
-            if (strpos($fileInfo['tags_html']['id3v1']['title'], 'explicit') !== false) {
+            $analysis['analysis']['title'] = $fileInfo['comments_html']['title'];
+            $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'][0];
+            $analysis['analysis']['album'] = $fileInfo['comments_html']['album'];
+            $analysis['analysis']['position'] = $fileInfo['comments_html']['track_number'];
+            if (strpos($fileInfo['comments_html']['title'], 'explicit') == true) {
                 $analysis['analysis']['explicit'] = true;
             } else {
                 $analysis['analysis']['explicit'] = false;

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -697,7 +697,9 @@ class MyRadio_Track extends ServiceAPI
             return $tracks;
         }
     }
-
+    /**
+      * Pay special attention to the tri-state value of explicit. False and null are different things.
+    */
     public static function identifyAndStoreTrack($tmpid, $title, $artist, $album, $position, $explicit = null)
     {
         // We need to rollback if something goes wrong later

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -636,7 +636,7 @@ class MyRadio_Track extends ServiceAPI
             $analysis['analysis']['title'] = $fileInfo['comments_html']['title'];
             $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'];
             $analysis['analysis']['album'] = $fileInfo['comments_html']['album'];
-            $analysis['analysis']['position'] = $fileInfo['comments_html']['track_number'];
+            $analysis['analysis']['position'] = $fileInfo['comments_html']['track_number'][0];
 
             $trackName = implode("", $fileInfo['comments_html']['title']);
             if (stripos($trackName, 'explicit') == true) {

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -657,6 +657,8 @@ class MyRadio_Track extends ServiceAPI
      * !This method requires the external lastfm-fpclient application to be installed on the server. A FreeBSD build
      * with URY's API key and support for -json can be found in the fpclient.git URY Git repository.
      *
+     ***** Since LastFM was removed from the central track uploader, this code MAY not be used anymore.
+     *
      * @param string $path The location of the MP3 file
      *
      * @return array A parsed array version of the JSON lastfm response

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -620,8 +620,7 @@ class MyRadio_Track extends ServiceAPI
         $getID3 = new \getID3();
         $fileInfo = $getID3->analyze(Config::$audio_upload_tmp_dir.'/'.$filename);
         $getID3_lib = new \getID3_lib();
-        $getID3_lib->CopyTagsToComments($fileInfo);
-        
+        $getID3_lib->CopyTagsToComments($fileInfo);       
 
         // File quality checks
         if ($fileInfo['audio']['bitrate'] < 192000) {
@@ -638,14 +637,12 @@ class MyRadio_Track extends ServiceAPI
         $analysis['analysis']['title'] = $fileInfo['comments_html']['title'];
         $analysis['analysis']['artist'] = $fileInfo['comments_html']['artist'];
         $analysis['analysis']['album'] = $fileInfo['comments_html']['album'];
-            
            
         //Remove total tracks in album from the track_number tag.
         $trackNo = explode("/", $fileInfo['comments_html']['track_number'][0], 2)[0];
         $analysis['analysis']['position'] = (string)$trackNo;
 
-        $trackName = implode("", $fileInfo['comments_html']['title']);
-           
+        $trackName = implode("", $fileInfo['comments_html']['title']);   
         $analysis['analysis']['explicit'] = !!stripos($trackName, 'explicit');
 
         return $analysis;

--- a/src/Controllers/Library/addTrack.php
+++ b/src/Controllers/Library/addTrack.php
@@ -4,6 +4,7 @@ use \MyRadio\MyRadio\CoreUtils;
 use \MyRadio\MyRadio\URLUtils;
 
 CoreUtils::getTemplateObject()->setTemplate('MyRadio/text.twig')
+    ->addVariable('title', 'Upload Track')
     ->addVariable(
         'text',
         '<iframe src="'

--- a/src/Controllers/NIPSWeb/confirm_central_upload.php
+++ b/src/Controllers/NIPSWeb/confirm_central_upload.php
@@ -11,7 +11,7 @@ $data = MyRadio_Track::identifyAndStoreTrack(
     $_REQUEST['artist'],
     $_REQUEST['album'],
     $_REQUEST['position'],
-    $_REQUEST['explicit'] ? true : null
+    filter_var($_REQUEST['explicit'], FILTER_VALIDATE_BOOLEAN) ? true : null
 );
 $data['fileid'] = $_REQUEST['fileid'];
 

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -58,14 +58,11 @@ body {
 }
 #central-status, #res-status {
   position: relative;
-  top: calc(100% - 60px);
+  top: calc(100% - 33px);
   left: -19px;
   width: calc(100% + 38px);
   height: 32px;
   padding-top: 5px;
-}
-#res-status {
-  top: calc(100% - 33px);
 }
 .result-container {
   width: 550px;
@@ -73,7 +70,7 @@ body {
 .result-container .alert {
   width: 100%;
   padding: 5px 15px 3px 15px;
-  margin: 0;
+  margin: 5px 0;
 }
 .result-container .alert-dismissable {
     padding-right: 35px;
@@ -120,12 +117,6 @@ body {
   }
 }
 
-#lastfm-attr {
-  position: relative;
-  top: calc(100% - 70px);
-  right: 1em;
-  text-align: right;
-}
 #baps-channel-res {
   height: calc(100% - 90px);
 }

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -72,6 +72,9 @@ body {
   padding: 5px 15px 3px 15px;
   margin: 5px 0;
 }
+.result-container .alert label {
+  margin-top: 6px;
+}
 .result-container .alert-dismissable {
     padding-right: 35px;
 }

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -52,7 +52,7 @@ body {
 }
 
 #central-dragdrop, #res-dragdrop {
-  height: 250px;
+  height: 150px;
   margin-bottom: 0;
   width: 550px;
 }
@@ -63,6 +63,9 @@ body {
   width: calc(100% + 38px);
   height: 32px;
   padding-top: 5px;
+}
+#res-type-sel {
+  margin-bottom: 10px;
 }
 .result-container {
   width: 550px;
@@ -76,46 +79,17 @@ body {
   margin-top: 6px;
 }
 .result-container .alert-dismissable {
-    padding-right: 35px;
+  padding-right: 35px;
 }
 /* Spin while saving tracks */
 .gly-spin {
-  -webkit-animation: spin 2s infinite linear;
-  -moz-animation: spin 2s infinite linear;
-  -o-animation: spin 2s infinite linear;
   animation: spin 2s infinite linear;
-}
-@-moz-keyframes spin {
-  0% {
-    -moz-transform: rotate(0deg);
-  }
-  100% {
-    -moz-transform: rotate(359deg);
-  }
-}
-@-webkit-keyframes spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(359deg);
-  }
-}
-@-o-keyframes spin {
-  0% {
-    -o-transform: rotate(0deg);
-  }
-  100% {
-    -o-transform: rotate(359deg);
-  }
 }
 @keyframes spin {
   0% {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(359deg);
     transform: rotate(359deg);
   }
 }

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -75,6 +75,51 @@ body {
   padding: 5px 15px 3px 15px;
   margin: 0;
 }
+.result-container .alert-dismissable {
+    padding-right: 35px;
+}
+/* Spin while saving tracks */
+.gly-spin {
+  -webkit-animation: spin 2s infinite linear;
+  -moz-animation: spin 2s infinite linear;
+  -o-animation: spin 2s infinite linear;
+  animation: spin 2s infinite linear;
+}
+@-moz-keyframes spin {
+  0% {
+    -moz-transform: rotate(0deg);
+  }
+  100% {
+    -moz-transform: rotate(359deg);
+  }
+}
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+  }
+}
+@-o-keyframes spin {
+  0% {
+    -o-transform: rotate(0deg);
+  }
+  100% {
+    -o-transform: rotate(359deg);
+  }
+}
+@keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
 #lastfm-attr {
   position: relative;
   top: calc(100% - 70px);

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -98,7 +98,7 @@ var Library = function () {
                         if (manual_div !== null) {
                             // If the div exists, then the user has permission to upload a track
                             // manually, so display the div and set manual_track to true.
-                            $(manual_div).show();
+                            $(manual_div).slideDown();
                             manual_track = true;
                         }
                     }
@@ -196,7 +196,7 @@ var Library = function () {
 
                             result.removeClass('alert-danger')
                             .addClass('alert-info')
-                            .html(track_title + ': Saving');
+                            .html('<div class="glyphicon glyphicon-refresh gly-spin"></div>&nbsp;<strong>' + track_title + '</strong> is saving...');
                             $.ajax(
                                 {
                                     url: myradio.makeURL('NIPSWeb', 'confirm_central_upload'),
@@ -214,12 +214,13 @@ var Library = function () {
                                         data.fileid = data.fileid.replace(/\.mp3/, '');
                                         if (data.status == 'OK') {
                                             result.removeClass('alert-info')
-                                            .addClass('alert-success')
-                                            .html('<div class="glyphicon glyphicon-ok"></div>&nbsp;' + track_title + ' uploaded');
+                                            .addClass('alert-success alert-dismissable')
+                                            .html('<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a><div class="glyphicon glyphicon-ok"></div>&nbsp;<strong>' + track_title + '</strong> uploaded successfully.');
+                                            $('#track-manual-entry').slideUp();
                                         } else {
                                             result.removeClass('alert-info')
                                             .addClass('alert-danger')
-                                            .html('<div class="glyphicon glyphicon-exclamation-sign"></div>&nbsp;' + track_title + ': ' + data.error);
+                                            .html('<div class="glyphicon glyphicon-exclamation-sign"></div>&nbsp;<strong>' + track_title + '</strong> ' + data.error);
                                         }
                                     }
                                 }

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -97,17 +97,17 @@ var Library = function () {
                         5000
                     )
 
-                    var manual_track = false;
+                    var submittable_track = false;
                     var manual_div = document.getElementById('track-manual-entry');
                         if (manual_div !== null) {
                             if (response['status'] !== 'OK' && response['submittable']) {
                                     // If the div exists, then the user has permission to upload a track
-                                    // manually, so display the div and set manual_track to true.
+                                    // manually, so display the div and set submittable_track to true.
                                     $(manual_div).slideDown();
-                                    manual_track = true;
+                                    submittable_track = true;
                             } else if (response['status'] !== 'OK' && response['submittable'] != true ) {
                                     $(manual_div).slideUp();
-                                    manual_track = false;
+                                    submittable_track = false;
                             } 
                             //Prevents any previous uploaded but not submitted tracks from being incorrectly submitted.
                             $('.current-track span').html(icon_error)
@@ -137,7 +137,7 @@ var Library = function () {
                     var track_album = "";
                     var track_position = "";
 
-                    if (manual_track) {
+                    if (submittable_track) {
                         if (response.analysis) {
                             //Otherwise, if we got an analysis from the ID3 tags, prefill the textboxes.
                             function decodeHtml(html) {
@@ -164,7 +164,7 @@ var Library = function () {
                     // The submit part
                     var submit = $('<button type="button" class="btn btn-primary">Save Track</button>').click(
                         function () {
-                            if (manual_track) {
+                            if (submittable_track) {
                                 track_fileid = response.fileid;
                                 track_title = document.getElementById('track-manual-entry-title').value;
                                 track_artist = document.getElementById('track-manual-entry-artist').value;
@@ -233,7 +233,7 @@ var Library = function () {
                     );
 
                     result.append('<label for="centralupload-' + i + '">' + file.name + ' &nbsp;</label>');
-                    if (manual_track) {
+                    if (submittable_track) {
                         $('#track-manual-entry form').append(submit);
                     }
                     $('#central-result').append(result);

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -116,6 +116,8 @@ var Library = function () {
                             $('.current-track').append('File was not submitted. ');
                             $('.current-track a').remove();
                             $('.current-track').removeClass('alert-info').addClass('alert-danger').removeClass('current-track'); 
+                            //Hide any previous form fill errors.
+                            $('.form-error').slideUp();
                         }       
                     var result = $('<div class="alert"></div>');
 
@@ -198,6 +200,7 @@ var Library = function () {
                             .addClass('alert-info')
                             .html(icon_loading + '<strong>' + track_title + '</strong> is saving...').slideDown();
                             $('#track-manual-entry').slideUp();
+                            $('.form-error').hide();
                             
                             $.ajax(
                                 {

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -256,27 +256,36 @@ var Library = function () {
                 maxfilesize: mConfig.audio_upload_max_size,
                 queuefiles: 1,
                 drop: function () {
-                    $('#res-status').html('Reading file (0%)...');
+                    $('#res-status').html(icon_loading + 'Reading file (0%)...');
                 },
                 uploadStarted: function (i, file, total) {
-                    $('#res-status').html('Uploading ' + file.name + '... (' + byteSize(file.size) + ')');
+                    $('#res-status').html(icon_loading + 'Uploading ' + file.name + '... (' + byteSize(file.size) + ')');
                 },
                 progressUpdated: function (i, file, progress) {
-                    $('#res-status').html('Reading ' + file.name + ' (' + progress + '%)...');
+                    $('#res-status').html(icon_loading + 'Reading ' + file.name + ' (' + progress + '%)...');
                 },
                 uploadFinished: function (i, file, response, time) {
-                    $('#res-status').html('Uploaded ' + file.name);
+                    $('#res-status').html(icon_ok + 'Uploaded ' + file.name);
 
                     var result = $('<div class="alert"></div>');
                     if (response['status'] == 'FAIL') {
                         //An error occurred
+                        alert('fail');
                         result.addClass('alert-danger').append('<span class="error">' + response['error'] + '</span>');
+                        $('#res-result').append(result);
                     } else {
                         result.addClass('alert-info').append(
-                            '<div id="resupload-' + i + '">' +
-                            file.name + ': <input type="text" class="title" name="' +
-                            response.fileid + '" id="resuploadname-' + i +
-                            '" placeholder="Enter a helpful name..." /></div>'
+                            '<div id="resupload-' + i + '" class="row">' + 
+                                '<label for="resuploadname-' + i + '" class="col-sm-4 control-label">' +
+                                    file.name + 
+                                ':</label>' +
+                                '<div class="col-sm-6">' + 
+                                    '<input type="text" class="title form-control" name="' +
+                                        response.fileid + '" id="resuploadname-' + i +
+                                    '" placeholder="Enter a helpful name..." />' +
+                                '</div>' +
+                            '</div>'
+                                
                         );
 
                         if (window.auxid.match(/^aux-\d+$/)) {
@@ -291,8 +300,8 @@ var Library = function () {
                             .append('<em>Leave blank to never expire</em>&nbsp;&nbsp;');
                         }
                         result.append('<div id="confirminator-' + (response.fileid.replace(/\.mp3/, '')) + '"></div>');
-                        result.append(
-                            $('<a href="javascript:">Save</a>').click(
+                        result.find('.row').append(
+                            $('<div class="col-sm-2"><button type="button" class="btn btn-primary save-button">Save</button></div>').click(
                                 function () {
                                     var title = result.find('input.title').val();
                                     var expire = result.find('input.date').val() || null;
@@ -315,12 +324,12 @@ var Library = function () {
                                                 if (data.status == 'OK') {
                                                     result.removeClass('alert-info')
                                                     .addClass('alert-success')
-                                                    .html('<div class="glyphicon glyphicon-ok"></div><em>' + title + '</em> added to library');
+                                                    .html(icon_ok + title + '</em> added to library');
                                                 } else {
                                                     result.removeClass('alert-info')
                                                     .addClass('alert-danger')
                                                     .html(
-                                                        '<div class="glyphicon glyphicon-exclamation-sign"></div><em>' + title + '</em> could not be added to library<br>'
+                                                        icon_error + title + '</em> could not be added to library.<br>'
                                                         + data.error
                                                     );
                                                 }
@@ -330,9 +339,8 @@ var Library = function () {
                                 }
                             )
                         );
-
-                        $('#res-result').append(result);
                     }
+                    $('#res-result').append(result);
                 }
             }
         );

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -1,16 +1,15 @@
 var Library = function () {
     var auxid = null;
-    var allowed_mp3 = ['audio/mpeg3', 'audio/x-mpeg-3', 'audio/mpeg', 'audio/x-mpeg',
+    const ALLOWED_MP3 = ['audio/mpeg3', 'audio/x-mpeg-3', 'audio/mpeg', 'audio/x-mpeg',
             'audio/mp3', 'audio/x-mp3', 'audio/mpg', 'audio/mpg3', 'audio/mpegaudio'];
-    var allowed_all = ['audio/mpeg3', 'audio/x-mpeg-3', 'audio/mpeg', 'audio/x-mpeg',
+    const ALLOWED_ALL = ['audio/mpeg3', 'audio/x-mpeg-3', 'audio/mpeg', 'audio/x-mpeg',
             'audio/mp3', 'audio/x-mp3', 'audio/mpg', 'audio/mpg3', 'audio/mpegaudio', 'audio/wav', 'audio/x-wav',
             'audio/mp4a-latm', 'audio/mp4', 'audio/aac'];
 
-    var icon_error = '<div class="glyphicon glyphicon-exclamation-sign"></div>&nbsp;';
-    var icon_ok = '<div class="glyphicon glyphicon-ok"></div>&nbsp;';
-    var icon_ok = '<div class="glyphicon glyphicon-ok"></div>&nbsp;';
-    var icon_loading = '<div class="glyphicon glyphicon-refresh gly-spin"></div>&nbsp;';
-    var icon_close = '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>';
+    const ICON_ERROR = '<div class="glyphicon glyphicon-exclamation-sign"></div>&nbsp;';
+    const ICON_OK = '<div class="glyphicon glyphicon-ok"></div>&nbsp;';
+    const ICON_LOADING = '<div class="glyphicon glyphicon-refresh gly-spin"></div>&nbsp;';
+    const ICON_CLOSE = '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>';
     //Converts bytes to human readable numbers
     var byteSize = function (size) {
         if (size > 1048576) {
@@ -71,27 +70,27 @@ var Library = function () {
                 url: myradio.makeURL('NIPSWeb', 'upload_central'),
                 paramname: 'audio',
                 error: filedrop_error_handler,
-                allowedfiletypes: allowed_mp3,
+                allowedfiletypes: ALLOWED_MP3,
                 maxfiles: 1,
                 maxfilesize: mConfig.audio_upload_max_size,
                 queuefiles: 1,
                 drop: function () {
-                    $('#central-status').html(icon_loading + 'Reading file (0%)...');
+                    $('#central-status').html(ICON_LOADING + 'Reading file (0%)...');
                 },
                 uploadStarted: function (i, file, total) {
-                    $('#central-status').html(icon_loading + 'Uploading ' + file.name + '... (' + byteSize(file.size) + ')');
+                    $('#central-status').html(ICON_LOADING + 'Uploading ' + file.name + '... (' + byteSize(file.size) + ')');
                 },
                 progressUpdated: function (i, file, progress) {
-                    $('#central-status').html(icon_loading + 'Reading ' + file.name + ' (' + progress + '%)...');
+                    $('#central-status').html(ICON_LOADING + 'Reading ' + file.name + ' (' + progress + '%)...');
                 },
                 uploadFinished: function (i, file, response, time) {
-                    var status = icon_ok + 'Uploaded ' + file.name;
+                    var status = ICON_OK + 'Uploaded ' + file.name;
                     $('#central-status').html(status);
 
                     setTimeout(
                         function () {
                             if ($('#central-status').html() == status) {
-                                $('#central-status').html(icon_ok + 'Ready');
+                                $('#central-status').html(ICON_OK + 'Ready');
                             }
                         },
                         5000
@@ -110,7 +109,7 @@ var Library = function () {
                                     submittable_track = false;
                             } 
                             //Prevents any previous uploaded but not submitted tracks from being incorrectly submitted.
-                            $('.current-track span').html(icon_error)
+                            $('.current-track span').html(ICON_ERROR)
                             $('.current-track').append('File was not submitted. ');
                             $('.current-track a').remove();
                             $('.current-track').removeClass('alert-info').addClass('alert-danger').removeClass('current-track'); 
@@ -123,7 +122,7 @@ var Library = function () {
                     if (response['status'] !== 'OK') {
                         if (response['status'] === 'FAIL') {
                             //An error occurred
-                            result.addClass('alert-danger').append('<span class="error">' + icon_error + response['message'] + ': </span>');
+                            result.addClass('alert-danger').append('<span class="error">' + ICON_ERROR + response['message'] + ': </span>');
                         } else if (response['status'] === 'INFO') {
                             //An info message has been sent (A song is now being edited)
                             result.addClass('alert-info current-track').append('<span class="error">' + response['message'] + ': </span>');
@@ -173,22 +172,22 @@ var Library = function () {
                                 track_explicit = document.getElementById('track-manual-entry-explicit').checked;
 
                                 if (!track_title) {
-                                    $('.form-error').html(icon_error + 'Please enter a title.').slideDown();
+                                    $('.form-error').html(ICON_ERROR + 'Please enter a title.').slideDown();
                                     $('#track-manual-entry-title').focus();
                                     return;
                                 }
                                 if (!track_artist) {
-                                    $('.form-error').html(icon_error + 'Please enter an artist.').slideDown();
+                                    $('.form-error').html(ICON_ERROR + 'Please enter an artist.').slideDown();
                                     $('#track-manual-entry-artist').focus();
                                     return;
                                 }
                                 if (!track_album) {
-                                    $('.form-error').html(icon_error + 'Please enter an album.').slideDown();
+                                    $('.form-error').html(ICON_ERROR + 'Please enter an album.').slideDown();
                                     $('#track-manual-entry-album').focus();
                                     return;
                                 }
                                 if (!track_position) {
-                                    $('.form-error').html(icon_error + 'Please enter a track number.').slideDown();
+                                    $('.form-error').html(ICON_ERROR + 'Please enter a track number.').slideDown();
                                     $('#track-manual-entry-position').focus();
                                     return;
                                 }
@@ -197,7 +196,7 @@ var Library = function () {
                             result.removeClass('alert-danger')
                             .addClass('alert-info')
                             .removeClass('current-track')
-                            .html(icon_loading + '<strong>' + track_title + '</strong> is saving...').slideDown();
+                            .html(ICON_LOADING + '<strong>' + track_title + '</strong> is saving...').slideDown();
                             $('#track-manual-entry').slideUp();
                             submit.remove();
                             $('.form-error').hide();
@@ -220,11 +219,11 @@ var Library = function () {
                                         if (data.status == 'OK') {
                                             result.removeClass('alert-info')
                                             .addClass('alert-success alert-dismissable')
-                                            .html(icon_close + icon_ok + '<strong>' + track_title + '</strong> uploaded successfully.');
+                                            .html(ICON_CLOSE + ICON_OK + '<strong>' + track_title + '</strong> uploaded successfully.');
                                         } else {
                                             result.removeClass('alert-info')
                                             .addClass('alert-danger alert-dismissable')
-                                            .html(icon_close + icon_error + '<strong>' + track_title + '</strong> ' + data.error);
+                                            .html(ICON_CLOSE + ICON_ERROR + '<strong>' + track_title + '</strong> ' + data.error);
                                         }
                                     }
                                 }
@@ -251,26 +250,26 @@ var Library = function () {
                 url: myradio.makeURL('NIPSWeb', 'upload_aux'),
                 paramname: 'audio',
                 error: filedrop_error_handler,
-                allowedfiletypes: allowed_all,
+                allowedfiletypes: ALLOWED_ALL,
                 maxfiles: 20,
                 maxfilesize: mConfig.audio_upload_max_size,
                 queuefiles: 1,
                 drop: function () {
-                    $('#res-status').html(icon_loading + 'Reading file (0%)...');
+                    $('#res-status').html(ICON_LOADING + 'Reading file (0%)...');
                 },
                 uploadStarted: function (i, file, total) {
-                    $('#res-status').html(icon_loading + 'Uploading ' + file.name + '... (' + byteSize(file.size) + ')');
+                    $('#res-status').html(ICON_LOADING + 'Uploading ' + file.name + '... (' + byteSize(file.size) + ')');
                 },
                 progressUpdated: function (i, file, progress) {
-                    $('#res-status').html(icon_loading + 'Reading ' + file.name + ' (' + progress + '%)...');
+                    $('#res-status').html(ICON_LOADING + 'Reading ' + file.name + ' (' + progress + '%)...');
                 },
                 uploadFinished: function (i, file, response, time) {
-                    $('#res-status').html(icon_ok + 'Uploaded ' + file.name);
+                    $('#res-status').html(ICON_OK + 'Uploaded ' + file.name);
 
                     var result = $('<div class="alert"></div>');
                     if (response['status'] == 'FAIL') {
                         //An error occurred, probably bitrate is too low.
-                        result.addClass('alert-danger alert-dismissable').append(icon_error + icon_close + '<strong>' + file.name + ':</strong> <span class="error">' + response['error'] + '</span>');
+                        result.addClass('alert-danger alert-dismissable').append(ICON_ERROR + ICON_CLOSE + '<strong>' + file.name + ':</strong> <span class="error">' + response['error'] + '</span>');
                         $('#res-result').append(result);
                     } else {
                         result.addClass('alert-info').append(
@@ -307,7 +306,7 @@ var Library = function () {
                                     var fileid = result.find('input.title').attr('name');
 
                                     if (!title) {
-                                        $('.form-error').html(icon_error + 'Please enter a title.').slideDown();
+                                        $('.form-error').html(ICON_ERROR + 'Please enter a title.').slideDown();
                                         //Flash the empty input
                                         result.find('input.title').prop('disabled', true); 
                                         setTimeout(
@@ -320,7 +319,7 @@ var Library = function () {
                                         return;
                                     }
 
-                                    result.html(icon_loading + 'Adding <strong>' + title + '</strong> to library...');
+                                    result.html(ICON_LOADING + 'Adding <strong>' + title + '</strong> to library...');
                                     $.ajax(
                                         {
                                             url: myradio.makeURL('NIPSWeb', 'confirm_aux_upload'),
@@ -337,12 +336,12 @@ var Library = function () {
                                                 if (data.status == 'OK') {
                                                     result.removeClass('alert-info')
                                                     .addClass('alert-success alert-dismissable')
-                                                    .html(icon_ok + icon_close + '<strong>' + title + ':</strong> was added to library.');
+                                                    .html(ICON_OK + ICON_CLOSE + '<strong>' + title + ':</strong> was added to library.');
                                                 } else {
                                                     result.removeClass('alert-info')
                                                     .addClass('alert-danger alert-dismissable')
                                                     .html(
-                                                        icon_error + icon_close + '<strong>' + title + ':</strong> could not be added to library.<br>Error: '
+                                                        ICON_ERROR + ICON_CLOSE + '<strong>' + title + ':</strong> could not be added to library.<br>Error: '
                                                         + data.error
                                                     );
                                                 }

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -289,17 +289,18 @@ var Library = function () {
 
                         if (window.auxid.match(/^aux-\d+$/)) {
                             //This is a central one - it can have an expiry
+                            result.append('<div class="row"><label for="resuploaddate-' + i + '" class="col-xs-4 control-label">Expiry Date: </label><div class="col-xs-6">');
                             result.append(
-                                $('<input type="text" placeholder="Expiry date" />').addClass('date').attr('id', 'resuploaddate-' + i).datetimepicker(
+                                $('<input type="text" placeholder="Leave blank to never expire." />').addClass('date form-control').attr('id', 'resuploaddate-' + i).datetimepicker(
                                     {
                                         pickTime: 'false'
                                     }
                                 )
                             )
-                            .append('<strong>Leave blank to never expire</strong>&nbsp;&nbsp;');
+                            result.append('</div></div>');
                         }
                         result.append('<div id="confirminator-' + (response.fileid.replace(/\.mp3/, '')) + '"></div>');
-                        result.find('.row').append(
+                        result.find('.row:first-of-type').append(
                             $('<div class="col-xs-2"><button type="button" class="btn btn-primary save-button">Save</button></div>').click(
                                 function () {
                                     var title = result.find('input.title').val();

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -164,7 +164,7 @@ var Library = function () {
                     }
 
                     // The submit part
-                    var submit = $('<a href="javascript:">Save' + (manual_track ? ' using below metadata' : '') + '</a>').click(
+                    var submit = $('<button type="button" class="btn btn-primary">Save Track</button>').click(
                         function () {
                             if (manual_track) {
                                 track_fileid = response.fileid;
@@ -198,8 +198,10 @@ var Library = function () {
 
                             result.removeClass('alert-danger')
                             .addClass('alert-info')
+                            .removeClass('current-track')
                             .html(icon_loading + '<strong>' + track_title + '</strong> is saving...').slideDown();
                             $('#track-manual-entry').slideUp();
+                            submit.remove();
                             $('.form-error').hide();
                             
                             $.ajax(
@@ -219,12 +221,10 @@ var Library = function () {
                                         data.fileid = data.fileid.replace(/\.mp3/, '');
                                         if (data.status == 'OK') {
                                             result.removeClass('alert-info')
-                                            .removeClass('current-track')
                                             .addClass('alert-success alert-dismissable')
                                             .html(icon_close + icon_ok + '<strong>' + track_title + '</strong> uploaded successfully.');
                                         } else {
                                             result.removeClass('alert-info')
-                                            .removeClass('current-track')
                                             .addClass('alert-danger alert-dismissable')
                                             .html(icon_close + icon_error + '<strong>' + track_title + '</strong> ' + data.error);
                                         }
@@ -237,7 +237,7 @@ var Library = function () {
                     result.append('<label for="centralupload-' + i + '">' + file.name + ' &nbsp;</label>');
                     //.append(select)
                     if (manual_track == true) {
-                        result.append(submit);
+                        $('#track-manual-entry form').append(submit);
                     }
                     $('#central-result').append(result);
                 }

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -107,16 +107,16 @@ var Library = function () {
                             } else if (response['status'] !== 'OK' && response['submittable'] != true ) {
                                     $(manual_div).slideUp();
                                     submittable_track = false;
-                            } 
+                            }
                             //Prevents any previous uploaded but not submitted tracks from being incorrectly submitted.
                             $('.current-track span').html(ICON_ERROR)
                             $('.current-track').append('File was not submitted. ');
                             $('.current-track a').remove();
-                            $('.current-track').removeClass('alert-info').addClass('alert-danger').removeClass('current-track'); 
+                            $('.current-track').removeClass('alert-info').addClass('alert-danger').removeClass('current-track');
                             //Hide any previous form fill errors.
                             $('.form-error').slideUp();
                             $('#track-manual-entry button').remove();
-                        }       
+                        }
                     var result = $('<div class="alert"></div>');
 
                     if (response['status'] !== 'OK') {
@@ -200,7 +200,7 @@ var Library = function () {
                             $('#track-manual-entry').slideUp();
                             submit.remove();
                             $('.form-error').hide();
-                            
+
                             $.ajax(
                                 {
                                     url: myradio.makeURL('NIPSWeb', 'confirm_central_upload'),
@@ -273,17 +273,17 @@ var Library = function () {
                         $('#res-result').append(result);
                     } else {
                         result.addClass('alert-info').append(
-                            '<div id="resupload-' + i + '" class="row">' + 
+                            '<div id="resupload-' + i + '" class="row">' +
                                 '<label for="resuploadname-' + i + '" class="col-xs-4 control-label">' +
-                                    file.name + 
+                                    file.name +
                                 ':</label>' +
-                                '<div class="col-xs-6">' + 
+                                '<div class="col-xs-6">' +
                                     '<input type="text" class="title form-control" name="' +
                                         response.fileid + '" id="resuploadname-' + i +
                                     '" placeholder="Enter a helpful name..." />' +
                                 '</div>' +
                             '</div>'
-                                
+
                         );
 
                         if (window.auxid.match(/^aux-\d+$/)) {
@@ -308,10 +308,10 @@ var Library = function () {
                                     if (!title) {
                                         $('.form-error').html(ICON_ERROR + 'Please enter a title.').slideDown();
                                         //Flash the empty input
-                                        result.find('input.title').prop('disabled', true); 
+                                        result.find('input.title').prop('disabled', true);
                                         setTimeout(
                                             function () {
-                                                result.find('input.title').prop('disabled', false); 
+                                                result.find('input.title').prop('disabled', false);
                                                 result.find('input.title').focus();
                                             },
                                             500

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -269,9 +269,8 @@ var Library = function () {
 
                     var result = $('<div class="alert"></div>');
                     if (response['status'] == 'FAIL') {
-                        //An error occurred
-                        alert('fail');
-                        result.addClass('alert-danger').append('<span class="error">' + response['error'] + '</span>');
+                        //An error occurred, probably bitrate is too low.
+                        result.addClass('alert-danger alert-dismissable').append(icon_error + icon_close + '<strong>' + file.name + ':</strong> <span class="error">' + response['error'] + '</span>');
                         $('#res-result').append(result);
                     } else {
                         result.addClass('alert-info').append(
@@ -297,7 +296,7 @@ var Library = function () {
                                     }
                                 )
                             )
-                            .append('<em>Leave blank to never expire</em>&nbsp;&nbsp;');
+                            .append('<strong>Leave blank to never expire</strong>&nbsp;&nbsp;');
                         }
                         result.append('<div id="confirminator-' + (response.fileid.replace(/\.mp3/, '')) + '"></div>');
                         result.find('.row').append(
@@ -307,7 +306,7 @@ var Library = function () {
                                     var expire = result.find('input.date').val() || null;
                                     var fileid = result.find('input.title').attr('name');
 
-                                    result.html('Adding <em>' + title + '</em> to library');
+                                    result.html(icon_loading + 'Adding <strong>' + title + '</strong> to library...');
                                     $.ajax(
                                         {
                                             url: myradio.makeURL('NIPSWeb', 'confirm_aux_upload'),
@@ -323,13 +322,13 @@ var Library = function () {
                                                 data.fileid = data.fileid.replace(/\.mp3/, '');
                                                 if (data.status == 'OK') {
                                                     result.removeClass('alert-info')
-                                                    .addClass('alert-success')
-                                                    .html(icon_ok + title + '</em> added to library');
+                                                    .addClass('alert-success alert-dismissable')
+                                                    .html(icon_ok + icon_close + '<strong>' + title + ':</strong> was added to library.');
                                                 } else {
                                                     result.removeClass('alert-info')
-                                                    .addClass('alert-danger')
+                                                    .addClass('alert-danger alert-dismissable')
                                                     .html(
-                                                        icon_error + title + '</em> could not be added to library.<br>'
+                                                        icon_error + icon_close + '<strong>' + title + ':</strong> could not be added to library.<br>Error: '
                                                         + data.error
                                                     );
                                                 }

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -289,15 +289,14 @@ var Library = function () {
 
                         if (window.auxid.match(/^aux-\d+$/)) {
                             //This is a central one - it can have an expiry
-                            result.append('<div class="row"><label for="resuploaddate-' + i + '" class="col-xs-4 control-label">Expiry Date: </label><div class="col-xs-6">');
-                            result.append(
+                            result.append('<div class="row"><label for="resuploaddate-' + i + '" class="col-xs-4 control-label">Expiry Date: </label><div class="col-xs-6 expiry-input"></div></div>');
+                            result.find('.expiry-input').html(
                                 $('<input type="text" placeholder="Leave blank to never expire." />').addClass('date form-control').attr('id', 'resuploaddate-' + i).datetimepicker(
                                     {
                                         pickTime: 'false'
                                     }
                                 )
                             )
-                            result.append('</div></div>');
                         }
                         result.append('<div id="confirminator-' + (response.fileid.replace(/\.mp3/, '')) + '"></div>');
                         result.find('.row:first-of-type').append(

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -309,6 +309,21 @@ var Library = function () {
                                     var expire = result.find('input.date').val() || null;
                                     var fileid = result.find('input.title').attr('name');
 
+                                    if (!title) {
+                                        $('.form-error').html(icon_error + 'Please enter a title.').slideDown();
+                                        //Flash the empty input
+                                        result.find('input.title').prop('disabled', true); 
+                                        setTimeout(
+                                            function () {
+                                                result.find('input.title').prop('disabled', false); 
+                                                result.find('input.title').focus();
+                                            },
+                                            500
+                                        )
+                                        
+                                        return;
+                                    }
+
                                     result.html(icon_loading + 'Adding <strong>' + title + '</strong> to library...');
                                     $.ajax(
                                         {

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -137,6 +137,21 @@ var Library = function () {
                                 select.append('<option value="' + value.title + ':-:' + value.artist + '">' + value.title + ' by ' + value.artist + '</option>');
                             }
                         );
+                    } else {
+                        if (response.analysis.length != 0) {
+                            document.getElementById('track-manual-entry-title').value = response.analysis.title;
+                            document.getElementById('track-manual-entry-artist').value = response.analysis.artist;
+                            document.getElementById('track-manual-entry-album').value = response.analysis.album;
+                            document.getElementById('track-manual-entry-position').value = response.analysis.position;
+                            document.getElementById('track-manual-entry-explicit').checked = response.analysis.explicit;
+                        } else {
+                            //this isn't right, should go into php file.
+                            document.getElementById('track-manual-entry-title').value = '';
+                            document.getElementById('track-manual-entry-artist').value = '';
+                            document.getElementById('track-manual-entry-album').value = '';
+                            document.getElementById('track-manual-entry-position').value = '';
+                            document.getElementById('track-manual-entry-explicit').checked = false;
+                        }
                     }
 
                     // The submit part

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -276,10 +276,10 @@ var Library = function () {
                     } else {
                         result.addClass('alert-info').append(
                             '<div id="resupload-' + i + '" class="row">' + 
-                                '<label for="resuploadname-' + i + '" class="col-sm-4 control-label">' +
+                                '<label for="resuploadname-' + i + '" class="col-xs-4 control-label">' +
                                     file.name + 
                                 ':</label>' +
-                                '<div class="col-sm-6">' + 
+                                '<div class="col-xs-6">' + 
                                     '<input type="text" class="title form-control" name="' +
                                         response.fileid + '" id="resuploadname-' + i +
                                     '" placeholder="Enter a helpful name..." />' +
@@ -301,7 +301,7 @@ var Library = function () {
                         }
                         result.append('<div id="confirminator-' + (response.fileid.replace(/\.mp3/, '')) + '"></div>');
                         result.find('.row').append(
-                            $('<div class="col-sm-2"><button type="button" class="btn btn-primary save-button">Save</button></div>').click(
+                            $('<div class="col-xs-2"><button type="button" class="btn btn-primary save-button">Save</button></div>').click(
                                 function () {
                                     var title = result.find('input.title').val();
                                     var expire = result.find('input.date').val() || null;

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -100,24 +100,23 @@ var Library = function () {
                     var manual_track = false;
                     var manual_div = document.getElementById('track-manual-entry');
                         if (manual_div !== null) {
-                            if (response['status'] !== 'OK' && response['submittable'] == true ) {
-                                
+                            if (response['status'] !== 'OK' && response['submittable']) {
                                     // If the div exists, then the user has permission to upload a track
                                     // manually, so display the div and set manual_track to true.
                                     $(manual_div).slideDown();
                                     manual_track = true;
-                                
                             } else if (response['status'] !== 'OK' && response['submittable'] != true ) {
                                     $(manual_div).slideUp();
                                     manual_track = false;
                             } 
-                            //Prevents any previous uploaded but not submmited tracks from being incorrectly submitted.
+                            //Prevents any previous uploaded but not submitted tracks from being incorrectly submitted.
                             $('.current-track span').html(icon_error)
                             $('.current-track').append('File was not submitted. ');
                             $('.current-track a').remove();
                             $('.current-track').removeClass('alert-info').addClass('alert-danger').removeClass('current-track'); 
                             //Hide any previous form fill errors.
                             $('.form-error').slideUp();
+                            $('#track-manual-entry button').remove();
                         }       
                     var result = $('<div class="alert"></div>');
 
@@ -137,7 +136,6 @@ var Library = function () {
                     var track_artist = "";
                     var track_album = "";
                     var track_position = "";
-
 
                     if (manual_track) {
                         if (response.analysis) {
@@ -235,7 +233,7 @@ var Library = function () {
                     );
 
                     result.append('<label for="centralupload-' + i + '">' + file.name + ' &nbsp;</label>');
-                    if (manual_track == true) {
+                    if (manual_track) {
                         $('#track-manual-entry form').append(submit);
                     }
                     $('#central-result').append(result);
@@ -319,7 +317,6 @@ var Library = function () {
                                             },
                                             500
                                         )
-                                        
                                         return;
                                     }
 
@@ -376,8 +373,6 @@ var Library = function () {
         initialise: initialise
     };
 }
-
-
 
 $(document).ready(
     function () {

--- a/src/Public/js/nipsweb.managelibrary.js
+++ b/src/Public/js/nipsweb.managelibrary.js
@@ -235,7 +235,6 @@ var Library = function () {
                     );
 
                     result.append('<label for="centralupload-' + i + '">' + file.name + ' &nbsp;</label>');
-                    //.append(select)
                     if (manual_track == true) {
                         $('#track-manual-entry form').append(submit);
                     }

--- a/src/Templates/NIPSWeb/manage_library_manual.twig
+++ b/src/Templates/NIPSWeb/manage_library_manual.twig
@@ -8,7 +8,7 @@
     <body>
   {% include 'NIPSWeb/res_selector.twig' %}
         <div id="central-container" class="res-container hidden">
-          <p><br>You can upload track to the central database by dragging them into the box below. I'll try to analyse the file and if I can figure out what it is, then I'll upload it for you. If the track is of poor quality then I will not allow tracks to be uploaded. If the track is not recognised in the Last.fm database, I will try to work out the details and you will be asked to check or enter the track details manually.</p>
+          <p><br>You can upload track to the central database by dragging them into the box below. I'll try to analyse the file and if I can figure out what it is, then I'll upload it for you. If the track is of poor quality then I will not allow tracks to be uploaded.</p>
           <div id="central-dragdrop" class="well">
             Drag MP3 files here to upload
             <div class="alert alert-warning" id="central-status">Getting set up...</div>

--- a/src/Templates/NIPSWeb/manage_library_manual.twig
+++ b/src/Templates/NIPSWeb/manage_library_manual.twig
@@ -9,16 +9,18 @@
   {% include 'NIPSWeb/res_selector.twig' %}
         <div id="central-container" class="res-container hidden">
           <p><br>You can upload track to the central database by dragging them into the box below. I'll try to analyse the file and if I can figure out what it is, then I'll upload it for you. If the track is of poor quality then I will not allow tracks to be uploaded. If the track is not recognised in the Last.fm database, I will try to work out the details and you will be asked to check or enter the track details manually.</p>
-          <div id="central-dragdrop" class="well">Drag MP3 files here to upload<div id="lastfm-attr">
-              <a href="http://www.last.fm/">Powered by <img src="http://cdn.last.fm/flatness/badges/lastfm_black_small.gif" /></a>
-          </div><div class="alert alert-warning" id="central-status">Getting set up...</div></div>
+          <div id="central-dragdrop" class="well">
+            Drag MP3 files here to upload
+            <div class="alert alert-warning" id="central-status">Getting set up...</div>
+          </div>
           <br>
           <div id="central-result" class="result-container"></div>
           <br>
           <div id="track-manual-entry" class="hidden panel panel-default">
-              <div class="panel-heading">Manual Track Listing</div>
+              <div class="panel-heading">Track Listing</div>
               <div class="panel-body">
-                <p>This track was not found in Last.fm's database. Please enter/check the details for this track manually and click "Save using below metadata" above.</p>
+                <p>Please enter/check the details for this track manually and click "Save using below metadata" above.</p>
+                <div class="alert alert-warning form-error" id="central-status" style="display:none;"></div>
                 <form>
                   <div class="form-group">
                     <label for="track-manual-entry-title">Title:</label>

--- a/src/Templates/NIPSWeb/manage_library_manual.twig
+++ b/src/Templates/NIPSWeb/manage_library_manual.twig
@@ -20,7 +20,7 @@
               <div class="panel-heading">Track Listing</div>
               <div class="panel-body">
                 <p>Please enter/check the details for this track manually and click "Save using below metadata" above.</p>
-                <div class="alert alert-warning form-error" id="central-status" style="display:none;"></div>
+                <div class="alert alert-warning form-error" style="display:none;"></div>
                 <form>
                   <div class="form-group">
                     <label for="track-manual-entry-title">Title:</label>

--- a/src/Templates/NIPSWeb/manage_library_manual.twig
+++ b/src/Templates/NIPSWeb/manage_library_manual.twig
@@ -8,7 +8,7 @@
     <body>
   {% include 'NIPSWeb/res_selector.twig' %}
         <div id="central-container" class="res-container hidden">
-          <p><br>You can upload track to the central database by dragging them into the box below. I'll try to analyse the file and if I can figure out what it is, then I'll upload it for you. If the track is of poor quality then I will not allow tracks to be uploaded.</p>
+          <p>You can upload track to the central database by dragging them into the box below. I'll try to analyse the file and if I can figure out what it is, then I'll upload it for you. If the track is of poor quality then I will not allow tracks to be uploaded.</p>
           <div id="central-dragdrop" class="well">
             Drag MP3 files here to upload
             <div class="alert alert-warning" id="central-status">Getting set up...</div>
@@ -48,7 +48,7 @@
         </div>
         <div id="managed-container" class="res-container hidden">Managed playlists are controlled using <a href="/itones/" target="_blank">Campus Playout Manager</a>. Entering them there also adds them to the wonderful Campus Jukebox</div>
         <div id="res-container" class="res-container hidden">
-          <p><br>You can upload track to this resource library by dragging them into the box below. Tracks uploaded must not return a match against our music analysis software.</p>
+          <p>You can upload track to this resource library by dragging them into the box below. Tracks uploaded must not return a match against our music analysis software.</p>
           <div id="res-dragdrop" class="well">Drag WAV/MP3 files here to upload<div class="alert alert-warning" id="res-status">Getting set up...</div></div>
           <div id="res-result" class="result-container"></div>
         </div>

--- a/src/Templates/NIPSWeb/manage_library_manual.twig
+++ b/src/Templates/NIPSWeb/manage_library_manual.twig
@@ -8,27 +8,45 @@
     <body>
   {% include 'NIPSWeb/res_selector.twig' %}
         <div id="central-container" class="res-container hidden">
-          <p>You can upload track to the central database by dragging them into the box below. I'll try to analyse the file and if I can figure out what it is, then I'll upload it for you. If the track is of poor quality then this tool will not allow tracks to be uploaded. If the track is not recognised, you will be asked to enter the track details manually.</p>
+          <p><br>You can upload track to the central database by dragging them into the box below. I'll try to analyse the file and if I can figure out what it is, then I'll upload it for you. If the track is of poor quality then I will not allow tracks to be uploaded. If the track is not recognised in the Last.fm database, I will try to work out the details and you will be asked to check or enter the track details manually.</p>
           <div id="central-dragdrop" class="well">Drag MP3 files here to upload<div id="lastfm-attr">
               <a href="http://www.last.fm/">Powered by <img src="http://cdn.last.fm/flatness/badges/lastfm_black_small.gif" /></a>
           </div><div class="alert alert-warning" id="central-status">Getting set up...</div></div>
+          <br>
           <div id="central-result" class="result-container"></div>
-
-          <div id="track-manual-entry" class="hidden">
-              <p>Track not found. Please enter the details manually:</p>
-              <form>
-              <label for="track-manual-entry-title">Title: </label><input type="text" id="track-manual-entry-title"><br>
-              <label for="track-manual-entry-artist">Artist: </label><input type="text" id="track-manual-entry-artist"><br>
-              <label for="track-manual-entry-album">Album: </label><input type="text" id="track-manual-entry-album"><br>
-              <label for="track-manual-entry-position">Track Number: </label><input type="number" id="track-manual-entry-position"><br>
-              <label for="track-manual-entry-explicit">Explicit?: <input type="checkbox" id="track-manual-entry-explicit">
-              </form>
+          <br>
+          <div id="track-manual-entry" class="hidden panel panel-default">
+              <div class="panel-heading">Manual Track Listing</div>
+              <div class="panel-body">
+                <p>This track was not found in Last.fm's database. Please enter/check the details for this track manually and click "Save using below metadata" above.</p>
+                <form>
+                  <div class="form-group">
+                    <label for="track-manual-entry-title">Title:</label>
+                    <input type="text" id="track-manual-entry-title" class="form-control">
+                  </div>
+                  <div class="form-group">
+                    <label for="track-manual-entry-artist">Artist:</label>
+                    <input type="text" id="track-manual-entry-artist" class="form-control">
+                  </div>
+                  <div class="form-group">
+                    <label for="track-manual-entry-album">Album:</label>
+                    <input type="text" id="track-manual-entry-album" class="form-control">
+                  </div>
+                  <div class="form-group">
+                    <label for="track-manual-entry-position">Track Number:</label>
+                    <input type="number" id="track-manual-entry-position" class="form-control">
+                  </div>
+                  <div class="checkbox">
+                    <label for="track-manual-entry-explicit"><input type="checkbox" id="track-manual-entry-explicit"> <strong>Explicit?</strong></label>    
+                  </div>
+                </form>
+              </div>
           </div>
 
         </div>
         <div id="managed-container" class="res-container hidden">Managed playlists are controlled using <a href="/itones/" target="_blank">Campus Playout Manager</a>. Entering them there also adds them to the wonderful Campus Jukebox</div>
         <div id="res-container" class="res-container hidden">
-          <p>You can upload track to this resource library by dragging them into the box below. Tracks uploaded must not return a match against our music analysis software.</p>
+          <p><br>You can upload track to this resource library by dragging them into the box below. Tracks uploaded must not return a match against our music analysis software.</p>
           <div id="res-dragdrop" class="well">Drag WAV/MP3 files here to upload<div class="alert alert-warning" id="res-status">Getting set up...</div></div>
           <div id="res-result" class="result-container"></div>
         </div>


### PR DESCRIPTION
Fixes: #613 

**New features added**
- Nice bootstrap styling everywhere.
- Uploading to Central Music Library now auto-fills from ID3 tags, including if track has "Explicit" in title.

**Fixes**
- Bitrate/Stereo Errors when uploading are now displayed when not uploading to the central music library.
- When uploading to the Central Music Library, if a track fails the bitrate or stereo test, the user can no longer still submit the track to the library.
- For the time being (until get round to making multi-uploads work properly), only one Central Library Track can be uploaded and submitted at a time. Once a track is submitted, another can be uploaded. If a new track is uploaded before one is submitted, the old track will be shown as not submitted, instead of the blue alert box being left on the page in a non-working manor.
- The broken LastFM integration has been removed.

**Testing Performed So Far**

_Central Music Library:_

- Bitrate error: Locally & myradio-dev.
- Stereo error: Locally & myradio-dev.
- Uploading & Submitting: Local & myradio-dev
- Auto ID3 Track Listing: Local & myradio-dev

_Resources:_

- Bitrate error: myradio-dev only (not available locally).
- Stereo error: myradio-dev only.
- Just Uploading: myradio-dev only.
- Uploading & submitting: Not yet.
- Jingles - Expiry Dates: Not yet.

_My Beds/Jingles_

- Bitrate error: Locally & myradio-dev.
- Stereo error: Locally & myradio-dev.
- Uploading & submitting: myradio-dev only

**Known Bugs**

- (FIXED) Manual Track Listing presence check errors don't quite fit the form.
- (FIXED) Manual Jingle etc. name presence checks cause a MyRadio Exception (as before).
