### PR TITLE
Add a track search API call

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Swagger.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger.php
@@ -200,7 +200,7 @@ class MyRadio_Swagger
                 $lines[] = '';
             } elseif (substr($line, 0, 1) === '@') {
                 $key = preg_replace('/^\@([a-zA-Z]+)(.*)$/', '$1', $line);
-                $keys[] = [ 'type' => $key, 'data' => trim(preg_replace('/^\@([a-zA-Z]+) (.*)$/', '$2', $line))];
+                $keys[] = ['type' => $key, 'data' => trim(preg_replace('/^\@([a-zA-Z]+) (.*)$/', '$2', $line))];
             } else {
                 $lines[sizeof($lines) - 1] .= $line.' ';
             }

--- a/src/Classes/ServiceAPI/MyRadio_Swagger.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger.php
@@ -200,7 +200,7 @@ class MyRadio_Swagger
                 $lines[] = '';
             } elseif (substr($line, 0, 1) === '@') {
                 $key = preg_replace('/^\@([a-zA-Z]+)(.*)$/', '$1', $line);
-                $keys[$key][] = trim(preg_replace('/^\@([a-zA-Z]+) (.*)$/', '$2', $line));
+                $keys[] = [ 'type' => $key, 'data' => trim(preg_replace('/^\@([a-zA-Z]+) (.*)$/', '$2', $line))];
             } else {
                 $lines[sizeof($lines) - 1] .= $line.' ';
             }
@@ -221,8 +221,8 @@ class MyRadio_Swagger
         //Now parse for docblock things
         $params = [];
         $return_type = 'Set';
-        foreach ($doc['keys'] as $key => $values) {
-            switch ($key) {
+        foreach ($doc['keys'] as $key) {
+            switch ($key['type']) {
                 //Deal with $params
                 case 'param':
                     /*
@@ -231,7 +231,7 @@ class MyRadio_Swagger
                      * info[2] should be parameter name
                      * info[3] should be the description
                      */
-                    $info = explode(' ', $values[0], 4);
+                    $info = explode(' ', $key['data'][0], 4);
                     $arg = str_replace('$', '', $info[2]); //Strip the $ from variable name
                     $params[$arg] = ['type' => $info[1], 'description' => empty($info[3]) ?: $info[3]];
                     break;
@@ -260,9 +260,10 @@ class MyRadio_Swagger
         $mixins = [];
         $return_type = 'Set';
         $deprecated = false;
+        $ignore = false;
         $method = 'auto';
-        foreach ($doc['keys'] as $key => $values) {
-            switch ($key) {
+        foreach ($doc['keys'] as $key) {
+            switch ($key['type']) {
                 //Deal with $params
                 case 'param':
                     /*
@@ -270,7 +271,7 @@ class MyRadio_Swagger
                      * info[1] should be parameter name
                      * info[2] should be the description
                      */
-                    $info = preg_split('/\s+/', $values[0], 3);
+                    $info = preg_split('/\s+/', $key['data'], 3);
                     $arg = str_replace('$', '', $info[1]); //Strip the $ from variable name
                     $params[$arg] = ['type' => $info[0], 'description' => empty($info[2]) ?: $info[2]];
                     break;
@@ -279,13 +280,18 @@ class MyRadio_Swagger
                      * info[0] should be the mixin name
                      * info[1] should be a description of what the mixin does
                      */
-                    foreach ($values as $value) {
+                    foreach ($key['data'] as $value) {
                         $info = explode(' ', $value, 2);
                         $mixins[$info[0]] = $info[1];
                     }
                     break;
                 case 'deprecated':
                     $deprecated = true;
+                    break;
+                case 'swagger':
+                    if ($key['data'][0] === 'ignore') {
+                        $ignore = true;
+                    }
                     break;
             }
         }
@@ -297,6 +303,7 @@ class MyRadio_Swagger
             'mixins' => $mixins,
             'return_type' => $return_type,
             'deprecated' => $deprecated,
+            'ignore' => $ignore
         ];
     }
 
@@ -310,9 +317,13 @@ class MyRadio_Swagger
     public static function getOptionsAllow(ReflectionMethod $method)
     {
         $info = self::parseDoc($method);
-        if (isset($info['keys']['api'])) {
-            return array_merge(['OPTIONS'], $info['keys']['api']);
-        } elseif (strncmp($method->getName(), 'set', strlen('set')) === 0) {
+        foreach ($info['keys'] as $key) {
+            if ($key['type'] === 'api') {
+                return array_merge(['OPTIONS'], $key['data']);
+            }
+        }
+        
+        if (strncmp($method->getName(), 'set', strlen('set')) === 0) {
             return ['OPTIONS', 'POST'];
         } else {
             return ['OPTIONS', 'GET'];

--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -69,11 +69,26 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
 
         $parameters = $method->getParameters();
 
-        if ($op === 'get' && $method->getNumberOfRequiredParameters() === 1) {
+        if (self::isOptionInPathForMethod($method)) {
             $args[$parameters[0]->getName()] = $arg0;
         }
 
         return $args;
+    }
+
+    /**
+     * Identify if this method should put its option in its path
+     * i.e. as /class/method/option
+     *
+     * @param ReflectionMethod The method
+     * @return bool
+     */
+    private static function isOptionInPathForMethod($method) {
+        $doc = self::getMethodDoc($method);
+        return self::getMethodOpType($method) === 'get' &&
+            $method->getNumberOfRequiredParameters() === 1 &&
+            self::getParamType($method->getParameters()[0], $doc) !== 'array';
+
     }
 
     /**
@@ -110,12 +125,13 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
             foreach (array_keys($paths) as $key) {
                 if (strpos($key, $path.'/{') === 0) {
                     $options[] = $key;
+                    break;
                 }
             }
 
             if (sizeof($options) > 1) {
                 throw new MyRadioException('Ambiguous path.', 404);
-            } elseif (sizeof($options) === 1) {
+            } elseif (self::isOptionInPathForMethod($method)) {
                 $path = $options[0];
             }
         }
@@ -263,7 +279,7 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
             $startIdx = 0;
             $paramReflectors = $method->getParameters();
 
-            if ($method->getNumberOfRequiredParameters() === 1 && $op === 'get') {
+            if (self::isOptionInPathForMethod($method)) {
                 //If only one GET is required, make it URL
                 $param = $method->getParameters()[0];
                 $parameters[] = [
@@ -308,6 +324,11 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
                     foreach ($child as $op => $reflector) {
                         $data = self::getMethodDoc($reflector);
 
+                        // Skip methods set to be skipped
+                        if ($data['ignore']) {
+                            continue;
+                        }
+
                         $paths['/'.$public_name.$method_name][$op] = [
                             'summary' => $data['short_desc'],
                             'description' => $data['long_desc'],
@@ -348,6 +369,44 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
         return $tags;
     }
 
+    private static function getMethodOpType($method)
+    {
+        $name = $method->getName();
+
+        //Note the ordering is important - create is static!
+        if (
+            CoreUtils::startsWith($name, 'create') ||
+            CoreUtils::startsWith($name, 'add')
+        ) {
+            return 'post';
+        }
+
+        if (
+            $name === 'toDataSource' ||
+            CoreUtils::startsWith($name, 'get') ||
+            CoreUtils::startsWith($name, 'is') ||
+            $method->isStatic()
+        ) {
+            return 'get';
+        }
+
+        return 'put';
+    }
+
+    private static function getMethodPublicName($method) {
+        $name = $method->getName();
+
+        if ($name === 'toDataSource' || $name === 'create') {
+            return '';
+        }
+
+        if (CoreUtils::startsWith($name, 'set') || CoreUtils::startsWith($name, 'get')) {
+            return '/'.strtolower(substr($name, 3));
+        }
+
+        return '/'.strtolower($name);
+    }
+
     public function getClassInfo()
     {
         $blocked_methods = [
@@ -378,44 +437,14 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
             }
 
             $name = $method->getName();
-
-            if ($name === 'toDataSource') {
-                $op = 'get';
-                $public_name = '';
-            } elseif (CoreUtils::startsWith($name, 'set')) {
-                $op = 'put';
-                $public_name = '/'.strtolower(substr($name, 3));
-            } elseif (CoreUtils::startsWith($name, 'get')) {
-                $op = 'get';
-                $public_name = '/'.strtolower(substr($name, 3));
-            } elseif (CoreUtils::startsWith($name, 'is')) {
-                $op = 'get';
-                $public_name = '/'.strtolower($name);
-            } elseif ($name === 'create') {
-                $op = 'post';
-                $public_name = '';
-            } elseif ($name === 'testCredentials') {
-                $op = 'post';
-                $public_name = '/'.strtolower($name);
-            } elseif (CoreUtils::startsWith($name, 'create')) {
-                $op = 'post';
-                $public_name = '/'.strtolower($name);
-            } elseif (CoreUtils::startsWith($name, 'add')) {
-                $op = 'post';
-                $public_name = '/'.strtolower($name);
-            } elseif ($method->isStatic()) {
-                $op = 'get';
-                $public_name = '/'.strtolower($name);
-            } else {
-                $op = 'put';
-                $public_name = '/'.strtolower($name);
-            }
+            $op = self::getMethodOpType($method);
+            $public_name = self::getMethodPublicName($method);
 
             if (!$method->isStatic()) {
                 $public_name = '/{id}'.$public_name;
             }
 
-            if ($op === 'get' && $method->getNumberOfRequiredParameters() === 1) {
+            if (self::isOptionInPathForMethod($method)) {
                 $public_name .= '/{'.$method->getParameters()[0]->getName().'}';
             }
 

--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -83,7 +83,8 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
      * @param ReflectionMethod The method
      * @return bool
      */
-    private static function isOptionInPathForMethod($method) {
+    private static function isOptionInPathForMethod($method)
+    {
         $doc = self::getMethodDoc($method);
         return self::getMethodOpType($method) === 'get' &&
             $method->getNumberOfRequiredParameters() === 1 &&


### PR DESCRIPTION
* Fix only one parameter having a type documented in the API.
* Fix putting single-parameter parameters into the path if they're arrays.
* Add a MyRadio_Track search method that can be used over the API.
* Fix findByOptions, because it turns out it's been broken since we moved the SQL out of the MyRadio_Track constructor and into getInstance.
* Tell Swagger not to expose findByOptions because its signature doesn't make sense for the API.
* Suck at splitting this into multiple commits