### PR TITLE
Fixes the Search API branch removing an API route

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -376,6 +376,7 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
 
         //Note the ordering is important - create is static!
         if (
+            $name === 'testCredentials' ||
             CoreUtils::startsWith($name, 'create') ||
             CoreUtils::startsWith($name, 'add')
         ) {


### PR DESCRIPTION
As part of refactoring some of the API logic, the explicit method route rules were refactored, and testCredentials was missed out.

This adds it back again.