### PR TITLE
Fix Math.Max

### DIFF
--- a/src/Public/js/nipsweb.player.js
+++ b/src/Public/js/nipsweb.player.js
@@ -1077,7 +1077,7 @@ var playoutSlider = function (e) {
         }
 
         slider.style.width = result + 'px';
-        return Math.Max(0, Math.round(result / getPixelsPerSecond() * 100) / 100);
+        return Math.max(0, Math.round(result / getPixelsPerSecond() * 100) / 100);
     };
 
     var getXOffset = function (e) {


### PR DESCRIPTION
Math.Max does not exist, but Math.max does. Fixes seeking in Show Planner.