### PR TITLE
Fix demos

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Demo.php
+++ b/src/Classes/ServiceAPI/MyRadio_Demo.php
@@ -69,12 +69,12 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
 
     public static function isUserAttendingDemo($demoid, $userid)
     {
-        $r = self::$db->fetchColumn(
-            'SELECT creditid FROM schedule.show_credit
+        $r = self::$db->fetchOne(
+            'SELECT COUNT(*) FROM schedule.show_credit
             WHERE show_id = 0 AND effective_from=$1 AND credit_type_id=7 AND creditid=$2',
             [self::getDemoTime($demoid), $userid]
         );
-        return count($r) > 0;
+        return $r[0] > 0;
     }
 
     public static function isSpaceOnDemo($demoid)
@@ -106,7 +106,7 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
         return (int) self::$db->fetchOne(
             'SELECT COUNT(*) FROM schedule.show_credit WHERE show_id = 0 AND effective_from=$1 AND credit_type_id=7',
             [self::getDemoTime($demoid)]
-        );
+        )[0];
     }
 
     /**
@@ -147,10 +147,11 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
 
         //Check they aren't already attending one in the next week
         if ((int) self::$db->fetchOne(
-            'SELECT COUNT(*) FROM schedule.show_credit WHERE show_id=0 AND creditid=$1
-            AND effective_from >= NOW() AND effective_from <= (NOW() + INTERVAL \'1 week\') LIMIT 1',
+            'SELECT COUNT(*) FROM schedule.show_credit
+            WHERE show_id=0 AND creditid=$1 AND effective_from >= NOW()
+              AND effective_from <= (NOW() + INTERVAL \'1 week\')',
             [$_SESSION['memberid']]
-        ) === 1) {
+        )[0] === 1) {
             return 2;
         }
 
@@ -225,7 +226,7 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
             'SELECT start_time FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1',
             [$demoid]
         );
-        return $r;
+        return $r[0];
     }
 
     public static function getDemoer($demoid)
@@ -235,6 +236,6 @@ class MyRadio_Demo extends MyRadio_Metadata_Common
             'SELECT memberid FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1',
             [$demoid]
         );
-        return MyRadio_User::getInstance($r);
+        return MyRadio_User::getInstance($r[0]);
     }
 }

--- a/src/Classes/ServiceAPI/MyRadio_Selector.php
+++ b/src/Classes/ServiceAPI/MyRadio_Selector.php
@@ -7,6 +7,7 @@ namespace MyRadio\ServiceAPI;
 
 use MyRadio\Config;
 use MyRadio\Database;
+use MyRadio\MyRadioEmail;
 use MyRadio\MyRadioException;
 use MyRadio\MyRadio\CoreUtils;
 use MyRadio\iTones\iTones_Utils;

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -1393,21 +1393,21 @@ class MyRadio_Track extends ServiceAPI
      */
     public static function getLibraryStats()
     {
-        $num_digitised = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE digitised=\'t\'');
-        $num_undigitised = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE digitised=\'f\'');
-        $num_clean = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE clean=\'y\'');
-        $num_unclean = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE clean=\'n\'');
-        $num_cleanunknown = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE clean=\'u\'');
+        $num_digitised = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE digitised=\'t\'')[0];
+        $num_undigitised = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE digitised=\'f\'')[0];
+        $num_clean = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE clean=\'y\'')[0];
+        $num_unclean = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE clean=\'n\'')[0];
+        $num_cleanunknown = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_track WHERE clean=\'u\'')[0];
 
         $num_verified = (int) self::$db->fetchOne(
             'SELECT COUNT(*) FROM public.rec_track WHERE digitised=\'t\' AND lastfm_verified=\'t\''
-        );
+        )[0];
         $num_unverified = (int) self::$db->fetchOne(
             'SELECT COUNT(*) FROM public.rec_track WHERE digitised=\'t\' AND lastfm_verified=\'f\''
-        );
+        )[0];
 
-        $num_singles = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_record WHERE format=\'s\'');
-        $num_albums = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_record WHERE format=\'a\'');
+        $num_singles = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_record WHERE format=\'s\'')[0];
+        $num_albums = (int) self::$db->fetchOne('SELECT COUNT(*) FROM public.rec_record WHERE format=\'a\'')[0];
 
         return [
             ['Key', 'Value'],


### PR DESCRIPTION
and other bad database function usage.

For some reason I decided that the database functions would be clever and only return a single value if that's what the query returned. This is of course not the case. Broke demos and getting library stats (but no one noticed this one). I've gone over the whole diff from #630 to find these, but you're welcome to go over it again

Of course, the true blame lies at whoever reviewed #630 ... ;)