### PR TITLE
Fix obit (part 2)

### DIFF
--- a/src/Classes/Config.php
+++ b/src/Classes/Config.php
@@ -678,6 +678,11 @@ final class Config
      */
     public static $account_expiry_before = 49;
 
+    /**
+     * The email list to send Obit activation notifications to.
+     */
+    public static $obit_list_id = 36;
+
     /**** DAEMON CONFIGURATION ****/
     public static $d_BAPSSync_enabled = false;
     public static $d_EmailQueue_enabled = true;

--- a/src/Classes/ServiceAPI/MyRadio_Selector.php
+++ b/src/Classes/ServiceAPI/MyRadio_Selector.php
@@ -7,6 +7,7 @@ namespace MyRadio\ServiceAPI;
 
 use MyRadio\Config;
 use MyRadio\Database;
+use MyRadio\MyRadioEmail;
 use MyRadio\MyRadioException;
 use MyRadio\MyRadio\CoreUtils;
 use MyRadio\iTones\iTones_Utils;

--- a/src/Classes/ServiceAPI/MyRadio_Selector.php
+++ b/src/Classes/ServiceAPI/MyRadio_Selector.php
@@ -439,7 +439,8 @@ class MyRadio_Selector
         self::setLock();
 
         //Email people
-        MyRadioEmail::sendEmailToComputing(
+        MyRadioEmail::sendEmailToList(
+            MyRadio_List::getInstance(Config::$obit_list_id),
             'OBIT INITIATED',
             'Urgent: Initiated Obit procedure for station as requested by '
             .MyRadio_User::getInstance()->getName().' - '


### PR DESCRIPTION
This change adds a missing namespace import (MyRadioEmail), and allow you to define a default list instead of just sending to Computing. The default value in the config is URY's Computing Team list, but it would probably be a good idea to update this to be a list specifically for obit (with a set of officer aliases).

Obit still currently gets stuck in a loop somewhere if caching is disabled. Which is a bit pants.