### PR TITLE
Stop Show Planner from forgetting to save changes.

### DIFF
--- a/src/Public/js/nipsweb.player.js
+++ b/src/Public/js/nipsweb.player.js
@@ -316,6 +316,8 @@ var NIPSWeb = function (d) {
            * the change log, and to propogate the changes to any other clients that may be active.
            */
           shipChanges(ops, addOp, next);
+        } else {
+          $(this).dequeue();
         }
       }
     );


### PR DESCRIPTION
Turns out hesitation was the key to breaking show planner.

If we decided that no change was actually made (we dragged to/from the same place), we didn't dequeue, preventing the next change from being sent off.