### PR TITLE
Only force API to non-array next shows if n=1.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -679,7 +679,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             }
         }
 
-        if (isset($response['next']) && sizeof($response['next']) === 1) {
+        if (isset($response['next']) && sizeof($response['next']) === 1 && $n==1) {
             $response['next'] = $response['next'][0];
         }
 


### PR DESCRIPTION
This fixes timelord with one show now returning still as an array.