### PR TITLE
Change the session serialization function to be the built-in serialize…

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Swagger.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger.php
@@ -451,14 +451,12 @@ class MyRadio_Swagger
      */
     protected static function getCurrentUserWithoutMessingWithSession()
     {
-        $dummysession = $_SESSION;
-        session_decode((new MyRadioSession())->read(session_id()));
-        if (!isset($_SESSION['memberid'])) {
+        $dummysession = unserialize((new MyRadioSession())->read(session_id()));
+        if (!isset($dummysession['memberid'])) {
             $user = null;
         } else {
-            $user = MyRadio_User::getInstance($_SESSION['memberid']);
+            $user = MyRadio_User::getInstance($dummysession['memberid']);
         }
-        $_SESSION = $dummysession;
 
         return $user;
     }

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -121,6 +121,10 @@ if ((!defined('DISABLE_SESSION')) or DISABLE_SESSION === false) {
     $session_handler = MyRadioNullSession::factory();
 }
 
+// Changing the serialize handler to the general serialize/unserialize methods lets us
+// read sessions without actually having to activate them and read them into $_SESSION
+ini_set('session.serialize_handler', 'php_serialize');
+
 session_set_save_handler(
     [$session_handler, 'open'],
     [$session_handler, 'close'],


### PR DESCRIPTION
…/unserialize methods, instead of slightly different internal ones, which enables the use of unserialize() to get at a session, instead of doing evil things to the  superglobal.