### PR TITLE
Ignore trailing slashes, as a blank method is technically a valid method

### DIFF
--- a/src/Controllers/api/v2.php
+++ b/src/Controllers/api/v2.php
@@ -16,6 +16,10 @@ if ($url === 'swagger.json') {
 
 // @todo: Isn't this some fun confusing spaghetti code. Need to refactor this routing.
 $parts = explode('/', $url);
+// Ignore trailing slashes
+if ($parts[sizeof($parts) - 1] === '') {
+    array_pop($parts);
+}
 $op = strtolower($_SERVER['REQUEST_METHOD']);
 $class = preg_replace('/[^0-9a-zA-Z-_]+/', '', $parts[0]);
 // Defaults to assuming the last field


### PR DESCRIPTION
This currently ends up entering the logic for three-block paths, when there's only two blocks.