### PR TITLE
Find tracks better in bloodhound menus

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -805,7 +805,7 @@ class MyRadio_Track extends ServiceAPI
             && !$options['recordid']
             && !$options['lastfmverified']
             && !$options['random']
-            && !$options['idsort']
+            &&  $options['idsort']
             && !$options['custom']
             && !$options['nocorrectionproposed']
             && !$options['clean']

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -109,10 +109,7 @@ var MyRadioForm = {
         dupDetector: function (remote, local) {
           return local.trackid == remote.trackid;
         },
-        prefetch: {
-          url: myradio.makeURL("MyRadio", "a-findtrack", {term: null, limit: 500})
-        },
-        remote: myradio.makeURL("MyRadio", "a-findtrack", {limit: 25, term: ""}) + "%QUERY" //Separated out otherwise % gets urlescaped
+        remote: myradio.makeURL("MyRadio", "a-findtrack", {limit: 25, require_digitised: true, term: ""}) + "%QUERY" //Separated out otherwise % gets urlescaped
       });
       trackLookup.initialize();
 


### PR DESCRIPTION
To fix problems with play listing where less useful (most likely ordered by oldest (lowest trackid) first) results caused the required track to be not selectable.