### PR TITLE
Fix several warnings and memory issues

### DIFF
--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -251,38 +251,6 @@ class Database
         throw new MyRadioException('Attempted to clone a singleton');
     }
 
-    /**
-     * Converts a postgresql array to a php array
-     * json_decode *nearly* works in some cases, but this tends to be more reliable.
-     *
-     * Based on http://stackoverflow.com/questions/3068683/convert-postgresql-array-to-php-array
-     *
-     * @deprecated Use json output from Postgres instead
-     */
-    public function decodeArray($text)
-    {
-        $limit = strlen($text) - 1;
-        $output = [];
-        $offset = 1;
-
-        if ('{}' != $text) {
-            do {
-                if ('{' != $text{$offset}) {
-                    preg_match('/(\\{?"([^"\\\\]|\\\\.)*"|[^,{}]+)+([,}]+)/', $text, $match, 0, $offset);
-                    $offset += strlen($match[0]);
-                    $output[] = ('"' != $match[1]{0} ? $match[1] : stripcslashes(substr($match[1], 1, -1)));
-                    if ('},' == $match[3]) {
-                        return $offset;
-                    }
-                } else {
-                    $offset = pg_array_parse($text, $output[], $limit, $offset + 1);
-                }
-            } while ($limit > $offset);
-        }
-
-        return $output;
-    }
-
     public function intervalToTime($interval)
     {
         return strtotime('1970-01-01 '.$interval.'+00');

--- a/src/Classes/ServiceAPI/MyRadio_Alias.php
+++ b/src/Classes/ServiceAPI/MyRadio_Alias.php
@@ -43,16 +43,24 @@ class MyRadio_Alias extends ServiceAPI
     protected function __construct($id)
     {
         $result = self::$db->fetchOne(
-            'SELECT source, '
-            .'(SELECT array(SELECT destination FROM mail.alias_text '
-            .'  WHERE alias_id=$1)) AS dtext, '
-            .'(SELECT array(SELECT destination FROM mail.alias_officer '
-            .'  WHERE alias_id=$1)) AS dofficer, '
-            .'(SELECT array(SELECT destination FROM mail.alias_member '
-            .'  WHERE alias_id=$1)) AS dmember, '
-            .'(SELECT array(SELECT destination FROM mail.alias_list '
-            .'  WHERE alias_id=$1)) AS dlist '
-            .'FROM mail.alias WHERE alias_id=$1',
+            'SELECT source, (
+                SELECT array_to_json(array(
+                    SELECT destination FROM mail.alias_text WHERE alias_id=$1
+                ))
+            ) AS dtext, (
+                SELECT array_to_json(array(
+                    SELECT destination FROM mail.alias_officer WHERE alias_id=$1
+                ))
+            ) AS dofficer, (
+                SELECT array_to_json(array(
+                    SELECT destination FROM mail.alias_member WHERE alias_id=$1
+                ))
+            ) AS dmember, (
+                SELECT array_to_json(array(
+                    SELECT destination FROM mail.alias_list WHERE alias_id=$1
+                ))
+            ) AS dlist
+            FROM mail.alias WHERE alias_id=$1',
             [$id]
         );
         if (empty($result)) {
@@ -61,28 +69,28 @@ class MyRadio_Alias extends ServiceAPI
             $this->alias_id = (int) $id;
             $this->source = $result['source'];
 
-            foreach (self::$db->decodeArray($result['dtext']) as $text) {
+            foreach (json_decode($result['dtext']) as $text) {
                 $this->destinations[] = [
                     'type' => 'text',
                     'value' => $text,
                 ];
             }
 
-            foreach (self::$db->decodeArray($result['dofficer']) as $officer) {
+            foreach (json_decode($result['dofficer']) as $officer) {
                 $this->destinations[] = [
                     'type' => 'officer',
                     'value' => MyRadio_Officer::getInstance($officer),
                 ];
             }
 
-            foreach (self::$db->decodeArray($result['dmember']) as $member) {
+            foreach (json_decode($result['dmember']) as $member) {
                 $this->destinations[] = [
                     'type' => 'member',
                     'value' => MyRadio_User::getInstance($member),
                 ];
             }
 
-            foreach (self::$db->decodeArray($result['dlist']) as $list) {
+            foreach (json_decode($result['dlist']) as $list) {
                 $this->destinations[] = [
                     'type' => 'list',
                     'value' => MyRadio_List::getInstance($list),

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -82,39 +82,39 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
 
         $result = self::$db->fetchOne(
             'SELECT file, memberid, approvedid, submitted, show_id, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT metadata_key_id FROM uryplayer.podcast_metadata
                     WHERE podcast_id=$1 AND effective_from <= NOW()
                     ORDER BY effective_from, podcast_metadata_id
-                )
+                ))
             ) AS metadata_types, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT metadata_value FROM uryplayer.podcast_metadata
                     WHERE podcast_id=$1 AND effective_from <= NOW()
                     ORDER BY effective_from, podcast_metadata_id
-                )
+                ))
             ) AS metadata, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT metadata_value FROM uryplayer.podcast_image_metadata
                     WHERE podcast_id=$1 AND effective_from <= NOW()
                     ORDER BY effective_from, podcast_image_metadata_id
-                )
+                ))
             ) AS image_metadata, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT credit_type_id FROM uryplayer.podcast_credit
                     WHERE podcast_id=$1 AND effective_from <= NOW()
                     AND (effective_to IS NULL OR effective_to >= NOW())
                     AND approvedid IS NOT NULL
                     ORDER BY podcast_credit_id
-                )
+                ))
             ) AS credit_types, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT creditid FROM uryplayer.podcast_credit
                     WHERE podcast_id=$1 AND effective_from <= NOW()
                     AND (effective_to IS NULL OR effective_to >= NOW())
                     AND approvedid IS NOT NULL
                     ORDER BY podcast_credit_id
-                )
+                ))
             ) AS credits
             FROM uryplayer.podcast
             LEFT JOIN schedule.show_podcast_link USING (podcast_id)
@@ -133,8 +133,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         $this->show_id = (int) $result['show_id'];
 
         //Deal with the Credits arrays
-        $credit_types = self::$db->decodeArray($result['credit_types']);
-        $credits = self::$db->decodeArray($result['credits']);
+        $credit_types = json_decode($result['credit_types']);
+        $credits = json_decode($result['credits']);
 
         for ($i = 0; $i < sizeof($credits); ++$i) {
             if (empty($credits[$i])) {
@@ -148,8 +148,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         }
 
         //Deal with the Metadata arrays
-        $metadata_types = self::$db->decodeArray($result['metadata_types']);
-        $metadata = self::$db->decodeArray($result['metadata']);
+        $metadata_types = json_decode($result['metadata_types']);
+        $metadata = json_decode($result['metadata']);
 
         for ($i = 0; $i < sizeof($metadata); ++$i) {
             if (self::isMetadataMultiple($metadata_types[$i])) {

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -40,46 +40,46 @@ class MyRadio_Season extends MyRadio_Metadata_Common
         //Get the basic info about the season
         $result = self::$db->fetchOne(
             'SELECT show_id, termid, submitted, memberid, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT metadata_key_id FROM schedule.season_metadata
                     WHERE show_season_id=$1 AND effective_from <= NOW()
                     AND (effective_to IS NULL OR effective_to >= NOW())
                     ORDER BY effective_from, season_metadata_id
-                )
+                ))
             ) AS metadata_types, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT metadata_value FROM schedule.season_metadata
                     WHERE show_season_id=$1 AND effective_from <= NOW()
                     AND (effective_to IS NULL OR effective_to >= NOW())
                     ORDER BY effective_from, season_metadata_id
-                )
+                ))
             ) AS metadata, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT requested_day FROM schedule.show_season_requested_time
                     WHERE show_season_id=$1 ORDER BY preference ASC
-                )
+                ))
             ) AS requested_days, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT start_time FROM schedule.show_season_requested_time
                     WHERE show_season_id=$1
                     ORDER BY preference ASC
-                )
+                ))
             ) AS requested_start_times, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT duration FROM schedule.show_season_requested_time
                     WHERE show_season_id=$1
                     ORDER BY preference ASC
-                )
+                ))
             ) AS requested_durations, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT show_season_timeslot_id FROM schedule.show_season_timeslot
                     WHERE show_season_id=$1
                     ORDER BY start_time ASC
-                )
+                ))
             ) AS timeslots, (
-                SELECT array(
+                SELECT array_to_json(array(
                     SELECT week FROM schedule.show_season_requested_week WHERE show_season_id=$1
-                )
+                ))
             ) AS requested_weeks, (
                 SELECT COUNT(*) FROM schedule.show_season
                 WHERE show_id=(SELECT show_id FROM schedule.show_season WHERE show_season_id=$1)
@@ -101,8 +101,8 @@ class MyRadio_Season extends MyRadio_Metadata_Common
         $this->term_id = (int) $result['termid'];
         $this->season_num = (int) $result['season_num'];
 
-        $metadata_types = self::$db->decodeArray($result['metadata_types']);
-        $metadata = self::$db->decodeArray($result['metadata']);
+        $metadata_types = json_decode($result['metadata_types']);
+        $metadata = json_decode($result['metadata']);
         //Deal with the metadata
         for ($i = 0; $i < sizeof($metadata_types); ++$i) {
             if (self::isMetadataMultiple($metadata_types[$i])) {
@@ -113,16 +113,16 @@ class MyRadio_Season extends MyRadio_Metadata_Common
         }
 
         //Requested Weeks
-        $requested_weeks = self::$db->decodeArray($result['requested_weeks']);
+        $requested_weeks = json_decode($result['requested_weeks']);
         $this->requested_weeks = [];
         foreach ($requested_weeks as $requested_week) {
             $this->requested_weeks[] = intval($requested_week);
         }
 
         //Requested timeslots
-        $requested_days = self::$db->decodeArray($result['requested_days']);
-        $requested_start_times = self::$db->decodeArray($result['requested_start_times']);
-        $requested_durations = self::$db->decodeArray($result['requested_durations']);
+        $requested_days = json_decode($result['requested_days']);
+        $requested_start_times = json_decode($result['requested_start_times']);
+        $requested_durations = json_decode($result['requested_durations']);
 
         for ($i = 0; $i < sizeof($requested_days); ++$i) {
             $this->requested_times[] = [
@@ -132,7 +132,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
             ];
         }
 
-        $this->timeslots = self::$db->decodeArray($result['timeslots']);
+        $this->timeslots = json_decode($result['timeslots']);
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -176,6 +176,7 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
             throw new MyRadioException("$path does not have a valid $op handler.", 405);
         }
 
+        // Note: May not contain a 'mixins' key. Don't add it either, or the empty array will get passed to functions
         $args = self::getArgs($op, $paths[$path][$op], $arg0);
 
         if ($id) {
@@ -193,7 +194,9 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
 
         if (!$caller) {
             throw new MyRadioException('No valid authentication data provided.', 401);
-        } elseif (self::validateRequest($caller, $classes[$class], $paths[$path][$op]->getName(), $args['mixins'])) {
+        } elseif (
+            self::validateRequest($caller, $classes[$class], $paths[$path][$op]->getName(), $args['mixins'] ?? [])
+        ) {
             $status = '200 OK';
             if ($paths[$path][$op]->getName() === 'create') {
                 $status = '201 Created';
@@ -205,7 +208,7 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
             $data = [
                 'status' => $status,
                 'content' => invokeArgsNamed($paths[$path][$op], $object, $args),
-                'mixins' => $args['mixins']
+                'mixins' => $args['mixins'] ?? []
             ];
 
             // If this returns a datasourceable array of objects, validate any mixins
@@ -216,7 +219,7 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
                 $sample_obj = $data;
             }
 
-            if ($sample_obj && !$caller->canMixin(get_class($sample_obj), $args['mixins'])) {
+            if ($sample_obj && !$caller->canMixin(get_class($sample_obj), $args['mixins'] ?? [])) {
                 throw new MyRadioException('Caller cannot access this method.', 403);
             }
 

--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -213,10 +213,13 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
 
             // If this returns a datasourceable array of objects, validate any mixins
             $sample_obj = null;
-            if (is_array($data) && sizeof($data) > 0 && is_subclass_of($data[0], 'MyRadio::ServiceAPI::ServiceAPI')) {
-                $sample_obj = $data[0];
-            } elseif (is_subclass_of($data, 'MyRadio::ServiceAPI::ServiceAPI')) {
-                $sample_obj = $data;
+            if (is_array($data['content'])
+                && sizeof($data['content']) > 0
+                && is_subclass_of(array_values($data['content'])[0], 'MyRadio::ServiceAPI::ServiceAPI')
+               ) {
+                $sample_obj = array_values($data['content'])[0];
+            } elseif (is_subclass_of($data['content'], 'MyRadio::ServiceAPI::ServiceAPI')) {
+                $sample_obj = $data['content'];
             }
 
             if ($sample_obj && !$caller->canMixin(get_class($sample_obj), $args['mixins'] ?? [])) {

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -48,35 +48,31 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         // Note that credits have different metadata timeranges to text
         // This is annoying, but needs to be this way.
         $result = self::$db->fetchOne(
-            'SELECT show_season_timeslot_id, show_season_id, start_time, duration, memberid,
-            (
-                SELECT array(
+            'SELECT show_season_timeslot_id, show_season_id, start_time, duration, memberid, (
+                SELECT array_to_json(array(
                     SELECT metadata_key_id FROM schedule.timeslot_metadata
                     WHERE show_season_timeslot_id=$1
                     AND effective_from < NOW()
                     AND (effective_to IS NULL OR effective_to > NOW())
                     ORDER BY effective_from, show_season_timeslot_id
-                )
-            ) AS metadata_types,
-            (
-                SELECT array(
+                ))
+            ) AS metadata_types, (
+                SELECT array_to_json(array(
                     SELECT metadata_value FROM schedule.timeslot_metadata
                     WHERE show_season_timeslot_id=$1
                     AND effective_from < NOW()
                     AND (effective_to IS NULL OR effective_to > NOW())
                     ORDER BY effective_from, show_season_timeslot_id
-                )
-            ) AS metadata,
-            (
+                ))
+            ) AS metadata, (
                 SELECT COUNT(*) FROM schedule.show_season_timeslot
                 WHERE show_season_id=(
                     SELECT show_season_id FROM schedule.show_season_timeslot
                     WHERE show_season_timeslot_id=$1
                 )
                 AND start_time<=(SELECT start_time FROM schedule.show_season_timeslot WHERE show_season_timeslot_id=$1)
-            ) AS timeslot_num,
-            (
-                SELECT array(
+            ) AS timeslot_num, (
+                SELECT array_to_json(array(
                     SELECT creditid FROM schedule.show_credit
                     WHERE show_id=(
                         SELECT show_id FROM schedule.show_season_timeslot
@@ -87,10 +83,9 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                     AND (effective_to IS NULL OR effective_to > start_time)
                     AND approvedid IS NOT NULL
                     ORDER BY show_credit_id
-                )
-            ) AS credits,
-            (
-                SELECT array(
+                ))
+            ) AS credits, (
+                SELECT array_to_json(array(
                     SELECT credit_type_id FROM schedule.show_credit
                     WHERE show_id=(
                         SELECT show_id FROM schedule.show_season_timeslot
@@ -101,7 +96,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                     AND (effective_to IS NULL OR effective_to > start_time)
                     AND approvedid IS NOT NULL
                     ORDER BY show_credit_id
-                )
+                ))
             ) AS credit_types
             FROM schedule.show_season_timeslot
             WHERE show_season_timeslot_id=$1',
@@ -120,8 +115,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         $this->owner = MyRadio_User::getInstance($result['memberid']);
         $this->timeslot_num = (int) $result['timeslot_num'];
 
-        $metadata_types = self::$db->decodeArray($result['metadata_types']);
-        $metadata = self::$db->decodeArray($result['metadata']);
+        $metadata_types = json_decode($result['metadata_types']);
+        $metadata = json_decode($result['metadata']);
         //Deal with the metadata
         for ($i = 0; $i < sizeof($metadata_types); ++$i) {
             if (self::isMetadataMultiple($metadata_types[$i])) {
@@ -132,8 +127,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         }
 
         //Deal with the Credits arrays
-        $credit_types = self::$db->decodeArray($result['credit_types']);
-        $credits = self::$db->decodeArray($result['credits']);
+        $credit_types = json_decode($result['credit_types']);
+        $credits = json_decode($result['credits']);
 
         for ($i = 0; $i < sizeof($credits); ++$i) {
             if (empty($credits[$i])) {


### PR DESCRIPTION
Turns out there are a lot of errors/warnings in MyRadio that we never see. Putting a log statement at https://github.com/UniversityRadioYork/MyRadio/blob/master/src/Classes/MyRadioError.php#L63 revealed many things, including many many thousands of unknown offsets from Database::decodeArray whenever certain people tried to select a timeslot. Presumably there's some text in there that the regex doesn't like.

Instead of trying to work out what was wrong with the horrible regex string, I just finished replacing it with the array_to_json/json_decode combo

Also fixed a couple of other errors that I was seeing in the same output log. There are more, but this cleans up the bulk of them (i.e. the ones that timelord uses every 3 seconds ;) )