### PR TITLE
Make setPayment update the user cache object when necessary

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -1229,7 +1229,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 );
                 $this->payment[$k]['paid'] = $amount;
                 $this->clearPermissionCache()->updateCacheObject();
-
+                $this->updateCacheObject();
                 return;
             }
         }
@@ -1242,7 +1242,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         );
         $this->payment[] = ['year' => $year, 'paid' => $amount];
         $this->clearPermissionCache()->updateCacheObject();
-
+        $this->updateCacheObject();
         return;
     }
 
@@ -1794,15 +1794,10 @@ class MyRadio_User extends ServiceAPI implements APICaller
      */
     public function activateMemberThisYear($paid = 0)
     {
-        if ($this->isActiveMemberForYear()) {
-            return true;
-        } else {
-            $year = CoreUtils::getAcademicYear();
-            $this->setPayment($paid, $year);
-            $this->updateCacheObject();
-
-            return true;
+        if (!$this->isActiveMemberForYear()) {
+            $this->setPayment($paid);
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
There's still some irritating code duplication in setPayment itself, but that can be fixed later

The other usage of setPayment is in markPaid.php and requires no changes