### PR TITLE
Add some space between city and country in SIS messages

### DIFF
--- a/src/Classes/SIS/SIS_Utils.php
+++ b/src/Classes/SIS/SIS_Utils.php
@@ -67,7 +67,7 @@ class SIS_Utils extends ServiceAPI
             } elseif (empty($geoip['city'])) {
                 $location[0] = "{$geoip['country_name']}";
             } else {
-                $location[0] = utf8_encode($geoip['city']) . "{$geoip['country_name']}";
+                $location[0] = utf8_encode($geoip['city']) . ", " . "{$geoip['country_name']}";
             }
 
             return $location;


### PR DESCRIPTION
Because "YorkUnited Kingdom" isn't quite as good as "York, United Kingdom".