### PR TITLE
Fixed Missing Telnet line for Jukebox API

### DIFF
--- a/src/Classes/iTones/iTones_Utils.php
+++ b/src/Classes/iTones/iTones_Utils.php
@@ -297,6 +297,7 @@ class iTones_Utils extends \MyRadio\ServiceAPI\ServiceAPI
             self::telnetStart();
         }
 
+        fwrite(self::$telnet_handle, $command."\n");
         $response = '';
         $line = '';
         $empty_line_counter = 0;


### PR DESCRIPTION
Fixes the speed issue with the getTrackForJukebox API and requesting tracks.

Turns out that after #708, the line was missing for telnet commands to be sent, so we didn't get a response, causing a timeout.