### PR TITLE
Add a couple of Podcast API features for 2016site

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -607,6 +607,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             'description' => $this->getMeta('description'),
             'status' => $this->getStatus(),
             'time' => $this->getSubmitted(),
+            'file' => $this->getFile(),
+            'webFile' => $this->getWebFile(),
             'photo' => Config::$public_media_uri.'/'.$this->getCover(),
             'editlink' => [
                 'display' => 'icon',

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -44,6 +44,13 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
     private $submitted;
 
     /**
+     * If the Podcast has been suspended.
+     *
+     * @var bool
+     */
+    private $suspended;
+
+    /**
      * The ID of the User that uploaded the Podcast.
      *
      * @var int
@@ -130,7 +137,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         $this->memberid = (int) $result['memberid'];
         $this->approvedid = (int) $result['approvedid'];
         $this->submitted = strtotime($result['submitted']);
-        $this->suspended = strtotime($result['suspended']);
+        $this->suspended = (bool) $result['suspended'];
         $this->show_id = (int) $result['show_id'];
 
         //Deal with the Credits arrays

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -794,13 +794,19 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
     /**
      * Returns all Podcasts. Caches for 1h.
      *
+     * @param int $noResults The number of results to return per page. 0 for all podcasts.
+     * @param int $page The page required.
+     *
      * @return Array[MyRadio_Podcast]
      */
-    public static function getAllPodcasts()
+    public static function getAllPodcasts($noResults = 0, $page = 1)
     {
+        $filterLimit = $noResults == 0 ? 'ALL' : $noResults;
+        $filterOffset = $noResults * $page;
         $result = self::$db->fetchColumn(
             'SELECT podcast_id FROM uryplayer.podcast
-            ORDER BY submitted DESC'
+            ORDER BY submitted DESC OFFSET $1 LIMIT $2',
+            [$filterOffset,$filterLimit]
         );
 
         $podcasts = [];

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -608,7 +608,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             'status' => $this->getStatus(),
             'time' => $this->getSubmitted(),
             'file' => $this->getFile(),
-            'webFile' => $this->getWebFile(),
+            'webfile' => $this->getWebFile(),
             'photo' => Config::$public_media_uri.'/'.$this->getCover(),
             'editlink' => [
                 'display' => 'icon',

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -137,7 +137,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         $this->memberid = (int) $result['memberid'];
         $this->approvedid = (int) $result['approvedid'];
         $this->submitted = strtotime($result['submitted']);
-        $this->suspended = (bool) $result['suspended'];
+        $this->suspended = ($result['suspended'] === 't') ? true : false;
         $this->show_id = (int) $result['show_id'];
 
         //Deal with the Credits arrays

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -513,7 +513,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
      *
      * @return bool
      */
-    public function getSuspended()
+    public function isSuspended()
     {
         return $this->suspended;
     }
@@ -589,7 +589,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         self::$db->query(
             'UPDATE uryplayer.podcast SET suspended=$1
             WHERE podcast_id=$2',
-            [$this->getSuspended(), $this->getID()]
+            [$this->isSuspended(), $this->getID()]
         );
 
         return $this;

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -835,18 +835,18 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
     /**
      * Returns all Podcasts. Caches for 1h.
      *
-     * @param int $noResults The number of results to return per page. 0 for all podcasts.
+     * @param int $num_results The number of results to return per page. 0 for all podcasts.
      * @param int $page The page required.
      *
      * @return Array[MyRadio_Podcast]
      */
-    public static function getAllPodcasts($noResults = 0, $page = 1)
+    public static function getAllPodcasts($num_results = 0, $page = 1)
     {
         $query = "SELECT podcast_id FROM uryplayer.podcast
                   ORDER BY submitted DESC OFFSET ";
 
-        $filterLimit = $noResults == 0 ? 'ALL' : $noResults;
-        $filterOffset = $noResults * $page;
+        $filterLimit = $num_results == 0 ? 'ALL' : $num_results;
+        $filterOffset = $num_results * $page;
 
         $query .= $filterOffset . " LIMIT " . $filterLimit;
         $result = self::$db->fetchColumn($query);

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -801,13 +801,14 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
      */
     public static function getAllPodcasts($noResults = 0, $page = 1)
     {
+        $query = "SELECT podcast_id FROM uryplayer.podcast
+                  ORDER BY submitted DESC OFFSET ";
+
         $filterLimit = $noResults == 0 ? 'ALL' : $noResults;
         $filterOffset = $noResults * $page;
-        $result = self::$db->fetchColumn(
-            'SELECT podcast_id FROM uryplayer.podcast
-            ORDER BY submitted DESC OFFSET $1 LIMIT $2',
-            [$filterOffset,$filterLimit]
-        );
+
+        $query .= $filterOffset . " LIMIT " . $filterLimit;
+        $result = self::$db->fetchColumn($query);
 
         $podcasts = [];
         foreach ($result as $row) {

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -519,7 +519,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
     }
 
     /**
-     * Get the value that *should* be stored in uryplayer.podcast.file.
+     * Get the value that *should* be stored in uryplayer.podcast.file when a new podcast is created.
      *
      * @return string
      */
@@ -607,8 +607,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             'description' => $this->getMeta('description'),
             'status' => $this->getStatus(),
             'time' => $this->getSubmitted(),
-            'file' => $this->getFile(),
-            'webfile' => $this->getWebFile(),
+            'uri' => $this->getURI(),
             'photo' => Config::$public_media_uri.'/'.$this->getCover(),
             'editlink' => [
                 'display' => 'icon',

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -583,7 +583,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
      *
      * @param bool $is_suspended
      */
-    public function setSuspended(bool $is_suspended) {
+    public function setSuspended(bool $is_suspended)
+    {
         $this->suspended = $is_suspended;
         self::$db->query(
             'UPDATE uryplayer.podcast SET suspended=$1

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -218,7 +218,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      *
      * @return MyRadio_Timeslot|null If null, Jukebox is next.
      */
-    public function getTimeslotAfter($filter = array(1))
+    public function getTimeslotAfter($filter = [1])
     {
         $filter = '{'.implode(', ', $filter).'}'; // lolphp http://php.net/manual/en/function.pg-query-params.php#71912
 
@@ -408,7 +408,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      *
      * @return MyRadio_Timeslot|null
      */
-    public static function getCurrentTimeslot($time = null, $filter = array(1))
+    public static function getCurrentTimeslot($time = null, $filter = [1])
     {
         self::initDB(); //First DB access for Timelord
         if ($time === null) {
@@ -444,7 +444,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      *
      * @return MyRadio_Timeslot
      */
-    public static function getPreviousTimeslots($time = null, $n = 1, $filter = array(1))
+    public static function getPreviousTimeslots($time = null, $n = 1, $filter = [1])
     {
         $filter = '{'.implode(', ', $filter).'}'; // lolphp http://php.net/manual/en/function.pg-query-params.php#71912
 
@@ -475,7 +475,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      *
      * @return MyRadio_Timeslot
      */
-    public static function getNextTimeslot($time = null, $filter = array(1))
+    public static function getNextTimeslot($time = null, $filter = [1])
     {
         $filter = '{'.implode(', ', $filter).'}'; // lolphp http://php.net/manual/en/function.pg-query-params.php#71912
 
@@ -624,7 +624,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      * @param int $n    number of next shows to return
      * @param $filter defines a filter of show_type ids
      */
-    public static function getCurrentAndNext($time = null, $n = 1, $filter = array(1))
+    public static function getCurrentAndNext($time = null, $n = 1, $filter = [1])
     {
         $isTerm = MyRadio_Scheduler::isTerm();
         $timeslot = self::getCurrentTimeslot($time, $filter);

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -439,6 +439,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      * Gets the previous Timeslots before $time, in reverse chronological order.
      *
      * @param int $time
+     * @param int $n defines the number of timeslots you want before this time.
      * @param     $filter defines a filter of show_type ids
      *
      * @return MyRadio_Timeslot
@@ -453,10 +454,10 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             INNER JOIN schedule.show_season USING (show_season_id)
             INNER JOIN schedule.show USING (show_id)
             WHERE start_time < $1
-            AND show_type_id = ANY ($2)
+            AND show_type_id = ANY ($3)
             ORDER BY start_time DESC
-            LIMIT $n',
-            [CoreUtils::getTimestamp($time), $filter]
+            LIMIT $2',
+            [CoreUtils::getTimestamp($time), $n, $filter]
         );
 
         if (empty($result)) {

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -444,7 +444,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      *
      * @return MyRadio_Timeslot
      */
-    public static function getPreviousTimeslots($time = null, $n=1, $filter = array(1))
+    public static function getPreviousTimeslots($time = null, $n = 1, $filter = array(1))
     {
         $filter = '{'.implode(', ', $filter).'}'; // lolphp http://php.net/manual/en/function.pg-query-params.php#71912
 

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -436,6 +436,37 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
     }
 
     /**
+     * Gets the previous Timeslots before $time, in reverse chronological order.
+     *
+     * @param int $time
+     * @param     $filter defines a filter of show_type ids
+     *
+     * @return MyRadio_Timeslot
+     */
+    public static function getPreviousTimeslots($time = null, $n=1, $filter = array(1))
+    {
+        $filter = '{'.implode(', ', $filter).'}'; // lolphp http://php.net/manual/en/function.pg-query-params.php#71912
+
+        $result = self::$db->fetchColumn(
+            'SELECT show_season_timeslot_id
+            FROM schedule.show_season_timeslot
+            INNER JOIN schedule.show_season USING (show_season_id)
+            INNER JOIN schedule.show USING (show_id)
+            WHERE start_time < $1
+            AND show_type_id = ANY ($2)
+            ORDER BY start_time DESC
+            LIMIT $n',
+            [CoreUtils::getTimestamp($time), $filter]
+        );
+
+        if (empty($result)) {
+            return;
+        } else {
+            return self::getInstance($result[0]);
+        }
+    }
+
+    /**
      * Gets the next Timeslot to start after $time.
      *
      * @param int $time

--- a/src/Public/js/myradio.podcasts.js
+++ b/src/Public/js/myradio.podcasts.js
@@ -21,6 +21,14 @@ $(".twig-datatable").dataTable({
     {
       "sTitle": "Time Submitted"
     },
+    // file
+    {
+      "bVisible": false
+    },
+    // webFile
+    {
+      "bVisible": false
+    },
     // photo
     {
       "bVisible": false


### PR DESCRIPTION
getPreviousTimeslots is used by UniversityRadioYork/2016-site#82 to get the "You just missed" mixcloud shows. Needs work/advice to actually get more than one result back.

Changes to toDataSource allow 2016-site to have a direct file URI to the podcast files.
Todo: Make sure the podcast interface within myradio hides the extra fields. DONE

Goes with UniversityRadioYork/myradio-go#42