### PR TITLE
Make RFTM use the correct API json file.

### DIFF
--- a/src/PublicAPI/rtfm/index.html
+++ b/src/PublicAPI/rtfm/index.html
@@ -37,7 +37,8 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "/api/v2/swagger.json";
+        var apiURL = location.pathname.substr(0, str.lastIndexOf("rtfm"));
+        url = apiURL + "v2/swagger.json";
       }
 
       hljs.configure({

--- a/src/PublicAPI/rtfm/index.html
+++ b/src/PublicAPI/rtfm/index.html
@@ -37,7 +37,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        var apiURL = location.pathname.substr(0, str.lastIndexOf("rtfm"));
+        var apiURL = location.pathname.substr(0, location.pathname.lastIndexOf("rtfm"));
         url = apiURL + "v2/swagger.json";
       }
 


### PR DESCRIPTION
This allows the RTFM swagger API documentation to follow the API it's installed in, instead of defaulting to the production one.