### PR TITLE
Always use integers for permissions

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_APIKey.php
+++ b/src/Classes/ServiceAPI/MyRadio_APIKey.php
@@ -41,9 +41,12 @@ class MyRadio_APIKey extends ServiceAPI implements APICaller
         $this->key = $key;
         $revoked = self::$db->fetchColumn('SELECT revoked from myury.api_key WHERE key_string=$1', [$key]);
         $this->revoked = ($revoked[0] == 't');
-        $this->permissions = self::$db->fetchColumn(
-            'SELECT typeid FROM myury.api_key_auth WHERE key_string=$1',
-            [$key]
+        $this->permissions = array_map(
+            'intval',
+            self::$db->fetchColumn(
+                'SELECT typeid FROM myury.api_key_auth WHERE key_string=$1',
+                [$key]
+            )
         );
     }
 

--- a/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
@@ -104,9 +104,12 @@ class MyRadio_TrainingStatus extends ServiceAPI
         $this->depends = empty($result['depends']) ? null : $result['depends'];
         $this->can_award = empty($result['can_award']) ? null : $result['can_award'];
 
-        $this->permissions = self::$db->fetchColumn(
-            'SELECT typeid FROM public.auth_trainingstatus WHERE presenterstatusid=$1',
-            [$statusid]
+        $this->permissions = array_map(
+            'intval',
+            self::$db->fetchColumn(
+                'SELECT typeid FROM public.auth_trainingstatus WHERE presenterstatusid=$1',
+                [$statusid]
+            )
         );
     }
 


### PR DESCRIPTION
When fetching permissions, always cast the IDs to integers. PHP doesn't particularly care, because why typing? However, this means that API calls such as /user/7449/permissions return a mixture of integer and strings-with-numbers-in, which can be Confusing.