### PR TITLE
Fix inconsistent nav width in SIS

### DIFF
--- a/src/Public/css/sis.css
+++ b/src/Public/css/sis.css
@@ -1,4 +1,4 @@
-.container {
+.main-container.container {
   width: calc(100% - 10px);
 }
 


### PR DESCRIPTION
Everywhere else (including other full width pages in MyRadio - Show Planner etc.) has the nav not full width. Makes SIS match.