### PR TITLE
Manual Tracklist Album Consistancies

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -425,7 +425,7 @@ class MyRadio_TracklistItem extends ServiceAPI
                     "last_modified" => null,
                     "location" => null,
                     "media" => "Manual Tracklist",
-                    "member_add" => $this->getTrack()->getDigitisedBy()->getMemberID(),
+                    "member_add" => null,
                     "member_edit" => null,
                     "record_label" => "",
                     "status" => "digital only",

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -414,7 +414,24 @@ class MyRadio_TracklistItem extends ServiceAPI
             // If manually tracklisted, track_norec table is just a plain text album.
             // Make it an array like regular tracks.
             if (!is_array($this->track["album"])) {
-                $this->track["album"] = MyRadio_Album::findOrCreate($this->track["album"], $this->track["artist"]);
+                $album = [
+                    "title" => $this->track["album"],
+                    "recordid" => null,
+                    "artist" => $this->track["artist"],
+                    "cdid" => null,
+                    "date_added" => date('d/m/Y H:i', $this->getStartTime()),
+                    "date_released" => null,
+                    "format" => "Album",
+                    "last_modified" => null,
+                    "location" => null,
+                    "media" => "Manual Tracklist",
+                    "member_add" => $this->getTrack()->getDigitisedBy()->getMemberID(),
+                    "member_edit" => null,
+                    "record_label" => "",
+                    "status" => "digital only",
+                    "label" => "Manual Tracklist"
+                ];
+                $this->track["album"] = $album;
             }
             $return = $this->track;
         } else {

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -411,6 +411,11 @@ class MyRadio_TracklistItem extends ServiceAPI
     public function toDataSource($mixins = [])
     {
         if (is_array($this->track)) {
+            // If manually tracklisted, track_norec table is just a plain text album.
+            // Make it an array like regular tracks.
+            if (!is_array($this->track["album"])) {
+                $this->track["album"] = MyRadio_Album::findOrCreate($this->track["album"], $this->track["artist"]);
+            }
             $return = $this->track;
         } else {
             $return = $this->getTrack()->toDataSource($mixins);


### PR DESCRIPTION
This fixes the fact that if a manual tracklist is made, the album appears as a plain text string in the API.

This is different from the full MyRadio_Album object for regular tracks.

Fixes UniversityRadioYork/2016-site#102 UniversityRadioYork/2016-site#46