### PR TITLE
Fix Bulk Add by fixing Text/Email fields in Tabularsets.

### DIFF
--- a/src/Classes/MyRadio/MyRadioFormField.php
+++ b/src/Classes/MyRadio/MyRadioFormField.php
@@ -593,6 +593,9 @@ class MyRadioFormField
      *
      * This is called by MyRadioForm::readValues()
      *
+     * Repeated elements -> TYPE_TABULARSET data has a little quirk. Because PHP, the table data is returned as a parent array of each
+     * column (not row), with child arrays containing each row value for each column. This is probably opposite to what you're thinking.
+     *
      * @param string $prefix The current prefix to the field name
      *
      * @return mixed The submitted field value
@@ -609,7 +612,7 @@ class MyRadioFormField
             case self::TYPE_TEXT:
             case self::TYPE_EMAIL:
             case self::TYPE_ARTIST:
-                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
+                //Deal with Arrays for repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {
                     $stripped_values = [];
                     foreach ($_REQUEST[$name] as $field_key => $field_value) {
@@ -638,7 +641,7 @@ class MyRadioFormField
                 return $_REQUEST[$name];
             break;
             case self::TYPE_MEMBER:
-                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
+                //Deal with Arrays for repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (empty($_REQUEST[$name][$i])) {
@@ -657,7 +660,7 @@ class MyRadioFormField
                 }
                 break;
             case self::TYPE_TRACK:
-                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
+                //Deal with Arrays for repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (empty($_REQUEST[$name][$i])) {
@@ -675,7 +678,7 @@ class MyRadioFormField
             case self::TYPE_SELECT:
             case self::TYPE_RADIO:
             case self::TYPE_DAY:
-                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
+                //Deal with Arrays for repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (is_numeric($_REQUEST[$name][$i])) {
@@ -695,7 +698,7 @@ class MyRadioFormField
             case self::TYPE_DATE:
             case self::TYPE_DATETIME:
             case self::TYPE_TIME:
-                //Deal with repeated elements (inc TYPE_TABULARSET)
+                //Deal with repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         $_REQUEST[$name][$i] = $this->convertTime($_REQUEST[$name][$i]);
@@ -783,7 +786,7 @@ class MyRadioFormField
                 return;
                 break;
             case self::TYPE_ALBUM:
-                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
+                //Deal with Arrays for repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (empty($_REQUEST[$name][$i])) {

--- a/src/Classes/MyRadio/MyRadioFormField.php
+++ b/src/Classes/MyRadio/MyRadioFormField.php
@@ -593,8 +593,9 @@ class MyRadioFormField
      *
      * This is called by MyRadioForm::readValues()
      *
-     * Repeated elements -> TYPE_TABULARSET data has a little quirk. Because PHP, the table data is returned as a parent array of each
-     * column (not row), with child arrays containing each row value for each column. This is probably opposite to what you're thinking.
+     * Repeated elements -> TYPE_TABULARSET data has a little quirk. Because PHP, the table data is returned as a 
+     * parent array of each column (not row), with child arrays containing each row value for each column.
+     * This is probably opposite to what you're thinking.
      *
      * @param string $prefix The current prefix to the field name
      *
@@ -622,7 +623,7 @@ class MyRadioFormField
                 } else {
                     return strip_tags($_REQUEST[$name]);
                 }
-            break;
+            	break;
             case self::TYPE_BLOCKTEXT:
                 $dom = new \DOMDocument();
                 // We have to wrap the html so that DOMDocument has a root
@@ -635,11 +636,11 @@ class MyRadioFormField
 
                 // Strip the <div> ... </div> nodes back off
                 return substr(trim($dom->saveHTML()), 5, -6);
-            break;
+            	break;
             case self::TYPE_HIDDEN:
             case self::TYPE_PASSWORD:
                 return $_REQUEST[$name];
-            break;
+            	break;
             case self::TYPE_MEMBER:
                 //Deal with Arrays for repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {

--- a/src/Classes/MyRadio/MyRadioFormField.php
+++ b/src/Classes/MyRadio/MyRadioFormField.php
@@ -606,11 +606,9 @@ class MyRadioFormField
         $name = $prefix.str_replace(' ', '_', $this->name);
         //The easiest ones can just be returned
         switch ($this->type) {
-            case self::TYPE_ARTIST:
-                return strip_tags($_REQUEST[$name]);
-            break;
             case self::TYPE_TEXT:
             case self::TYPE_EMAIL:
+            case self::TYPE_ARTIST:
                 //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
                 if (is_array($_REQUEST[$name])) {
                     $stripped_values = [];

--- a/src/Classes/MyRadio/MyRadioFormField.php
+++ b/src/Classes/MyRadio/MyRadioFormField.php
@@ -606,10 +606,21 @@ class MyRadioFormField
         $name = $prefix.str_replace(' ', '_', $this->name);
         //The easiest ones can just be returned
         switch ($this->type) {
-            case self::TYPE_TEXT:
-            case self::TYPE_EMAIL:
             case self::TYPE_ARTIST:
                 return strip_tags($_REQUEST[$name]);
+            break;
+            case self::TYPE_TEXT:
+            case self::TYPE_EMAIL:
+                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
+                if (is_array($_REQUEST[$name])) {
+                    $stripped_values = [];
+                    foreach ($_REQUEST[$name] as $field_key => $field_value) {
+                        $stripped_values[$field_key] = strip_tags($field_value);
+                    }
+                    return $stripped_values;
+                } else {
+                    return strip_tags($_REQUEST[$name]);
+                }
             break;
             case self::TYPE_BLOCKTEXT:
                 $dom = new \DOMDocument();
@@ -629,7 +640,7 @@ class MyRadioFormField
                 return $_REQUEST[$name];
             break;
             case self::TYPE_MEMBER:
-                //Deal with Arrays for repeated elements
+                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (empty($_REQUEST[$name][$i])) {
@@ -648,7 +659,7 @@ class MyRadioFormField
                 }
                 break;
             case self::TYPE_TRACK:
-                //Deal with Arrays for repeated elements
+                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (empty($_REQUEST[$name][$i])) {
@@ -666,7 +677,7 @@ class MyRadioFormField
             case self::TYPE_SELECT:
             case self::TYPE_RADIO:
             case self::TYPE_DAY:
-                //Deal with Arrays for repeated elements
+                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (is_numeric($_REQUEST[$name][$i])) {
@@ -686,7 +697,7 @@ class MyRadioFormField
             case self::TYPE_DATE:
             case self::TYPE_DATETIME:
             case self::TYPE_TIME:
-                //Deal with repeated elements
+                //Deal with repeated elements (inc TYPE_TABULARSET)
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         $_REQUEST[$name][$i] = $this->convertTime($_REQUEST[$name][$i]);
@@ -774,7 +785,7 @@ class MyRadioFormField
                 return;
                 break;
             case self::TYPE_ALBUM:
-                //Deal with Arrays for repeated elements
+                //Deal with Arrays for repeated elements (inc TYPE_TABULARSET)
                 if (is_array($_REQUEST[$name])) {
                     for ($i = 0; $i < sizeof($_REQUEST[$name]); ++$i) {
                         if (empty($_REQUEST[$name][$i])) {

--- a/src/Classes/MyRadio/MyRadioFormField.php
+++ b/src/Classes/MyRadio/MyRadioFormField.php
@@ -593,7 +593,7 @@ class MyRadioFormField
      *
      * This is called by MyRadioForm::readValues()
      *
-     * Repeated elements -> TYPE_TABULARSET data has a little quirk. Because PHP, the table data is returned as a 
+     * Repeated elements -> TYPE_TABULARSET data has a little quirk. Because PHP, the table data is returned as a
      * parent array of each column (not row), with child arrays containing each row value for each column.
      * This is probably opposite to what you're thinking.
      *
@@ -623,7 +623,7 @@ class MyRadioFormField
                 } else {
                     return strip_tags($_REQUEST[$name]);
                 }
-            	break;
+                break;
             case self::TYPE_BLOCKTEXT:
                 $dom = new \DOMDocument();
                 // We have to wrap the html so that DOMDocument has a root
@@ -636,11 +636,11 @@ class MyRadioFormField
 
                 // Strip the <div> ... </div> nodes back off
                 return substr(trim($dom->saveHTML()), 5, -6);
-            	break;
+                break;
             case self::TYPE_HIDDEN:
             case self::TYPE_PASSWORD:
                 return $_REQUEST[$name];
-            	break;
+                break;
             case self::TYPE_MEMBER:
                 //Deal with Arrays for repeated elements - see function comment.
                 if (is_array($_REQUEST[$name])) {

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -2030,6 +2030,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 'bulkaddrepeater',
                 MyRadioFormField::TYPE_TABULARSET,
                 [
+                    'label' => "Member Details",
                     'options' => [
                         new MyRadioFormField(
                             'fname',


### PR DESCRIPTION
Fixes ***Warning : strip_tags() expects parameter 1 to be string, array given - In /usr/local/www/myradio/src/Classes/MyRadio/MyRadioFormField.php on line 612*** errors.