### PR TITLE
Limit the length of tags and comma delimit.

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -84,7 +84,7 @@ pg_createcluster 10 myradio
 su - postgres -c "cat /vagrant/sample_configs/postgres.sql | psql"
 
 # Somewhere to store audio uploads
-music_dirs="records membersmusic beds jingles"
+music_dirs="records membersmusic beds jingles podcasts"
 for i in ${music_dirs}; do # no spaces
 	mkdir -p /music/$i
 	chown www-data:www-data /music/$i

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -651,7 +651,8 @@ class CoreUtils
         return $exploded_tags;
     }
 
-    public static function checkUploadPostSize(){
+    public static function checkUploadPostSize()
+    {
         // Check that any files don't go over the PHP post_max_size
         // Otherwise, sometimes PHP won't return an error, causing an empty $_POST.
         // This would cause confusing errors relating to empty fields.

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -620,6 +620,34 @@ class CoreUtils
         return $needle === '' || strrpos($haystack, $needle, -strlen($haystack)) !== false;
     }
 
+    /**
+     * Explode tags from string to array.
+     * We want to handle the case when people delimit with commas, spaces, or commas and
+     * spaces, as well as handling extended spaces.
+     *
+     * @param string $tags A tags string, comma separated.
+     *
+     * @return array The exploded tags.
+     *
+     * @throws MyRadioException when tags are longer than 24 characters.
+    **/
+    public static function explodeTags($tags)
+    {
+        $tags = preg_split('/[, ] */', $tags, null, PREG_SPLIT_NO_EMPTY);
+        $exploded_tags = [];
+        foreach ($tags as $tag) {
+            if (empty($tag)) {
+                continue;
+            }
+            if (strlen($tag) > 24) {
+                throw new MyRadioException('Sorry, individual tags longer than 24 characters
+                    aren\'t allowed. Please try again.', 400);
+            }
+            $exploded_tags += $tag;
+        }
+        return $exploded_tags;
+    }
+
     private function __construct()
     {
     }

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -650,6 +650,37 @@ class CoreUtils
         return $exploded_tags;
     }
 
+    public static function checkUploadPostSize(){
+        // Check that any files don't go over the PHP post_max_size
+        // Otherwise, sometimes PHP won't return an error, causing an empty $_POST.
+        // This would cause confusing errors relating to empty fields.
+        // @see https://stackoverflow.com/questions/2133652/how-to-gracefully-handle-files-that-exceed-phps-post-max-size
+        $post_size = trim(ini_get('post_max_size'));
+        if ($post_size != '') {
+            $last = strtolower(substr($post_size, -1));
+        } else {
+            $last = '';
+        }
+        switch ($last) {
+            // The 'G' modifier is available since PHP 5.1.0
+            case 'g':
+                $post_size *= 1024;
+                // fall through
+            case 'm':
+                $post_size *= 1024;
+                // fall through
+            case 'k':
+                $post_size *= 1024;
+                // fall through
+        }
+        if ($_SERVER['CONTENT_LENGTH'] > $post_size) {
+            throw new MyRadioException(
+                "The content uploaded in this form was too large for the server's configuration.",
+                500
+            );
+        }
+    }
+
     private function __construct()
     {
     }

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -643,7 +643,7 @@ class CoreUtils
                 throw new MyRadioException('Sorry, individual tags longer than 24 characters
                     aren\'t allowed. Please try again.', 400);
             }
-            $exploded_tags += $tag;
+            $exploded_tags += trim($tag);
         }
         return $exploded_tags;
     }

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -643,7 +643,8 @@ class CoreUtils
                 throw new MyRadioException('Sorry, individual tags longer than 24 characters
                     aren\'t allowed. Please try again.', 400);
             }
-            $exploded_tags += trim($tag);
+            // Add the valid tag to the returned array.
+            $exploded_tags[] = trim($tag);
         }
         return $exploded_tags;
     }

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -640,8 +640,9 @@ class CoreUtils
                 continue;
             }
             if (strlen($tag) > 24) {
-                throw new MyRadioException('Sorry, individual tags longer than 24 characters
-                    aren\'t allowed. Please try again.', 400);
+                throw new MyRadioException(
+                    "Sorry, individual tags longer than 24 characters aren't allowed. Please try again.",
+                    400);
             }
             // Add the valid tag to the returned array.
             $exploded_tags[] = trim($tag);

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -642,7 +642,8 @@ class CoreUtils
             if (strlen($tag) > 24) {
                 throw new MyRadioException(
                     "Sorry, individual tags longer than 24 characters aren't allowed. Please try again.",
-                    400);
+                    400
+                );
             }
             // Add the valid tag to the returned array.
             $exploded_tags[] = trim($tag);
@@ -654,7 +655,7 @@ class CoreUtils
         // Check that any files don't go over the PHP post_max_size
         // Otherwise, sometimes PHP won't return an error, causing an empty $_POST.
         // This would cause confusing errors relating to empty fields.
-        // @see https://stackoverflow.com/questions/2133652/how-to-gracefully-handle-files-that-exceed-phps-post-max-size
+        // https://stackoverflow.com/questions/2133652/how-to-gracefully-handle-files-that-exceed-phps-post-max-size
         $post_size = trim(ini_get('post_max_size'));
         if ($post_size != '') {
             $last = strtolower(substr($post_size, -1));

--- a/src/Classes/MyRadio/MyRadioForm.php
+++ b/src/Classes/MyRadio/MyRadioForm.php
@@ -2,6 +2,7 @@
 
 namespace MyRadio\MyRadio;
 
+use MyRadio\CoreUtils;
 use MyRadio\MyRadioException;
 use MyRadio\Config;
 
@@ -379,36 +380,7 @@ class MyRadioForm
      */
     public function readValues()
     {
-        // Check that any files don't go over the PHP post_max_size
-        // Otherwise, sometimes PHP won't return an error, causing an empty $_POST.
-        // This would cause confusing errors relating to empty fields.
-        // @see https://stackoverflow.com/questions/2133652/how-to-gracefully-handle-files-that-exceed-phps-post-max-size
-        $post_size = trim(ini_get('post_max_size'));
-        if ($post_size != '') {
-            $last = strtolower(
-                $post_size{strlen($post_size) - 1}
-            );
-        } else {
-            $last = '';
-        }
-        switch ($last) {
-            // The 'G' modifier is available since PHP 5.1.0
-            case 'g':
-                $post_size *= 1024;
-                // fall through
-            case 'm':
-                $post_size *= 1024;
-                // fall through
-            case 'k':
-                $post_size *= 1024;
-                // fall through
-        }
-        if ($_SERVER['CONTENT_LENGTH'] > $post_size) {
-            throw new MyRadioException(
-                "The content uploaded in this form was too large for the server's configuration.",
-                500
-            );
-        }
+        CoreUtils::checkUploadPostSize();
 
         //If there was a captcha, verify it
         if ($this->captcha) {

--- a/src/Classes/MyRadio/MyRadioForm.php
+++ b/src/Classes/MyRadio/MyRadioForm.php
@@ -405,7 +405,7 @@ class MyRadioForm
         }
         if ($_SERVER['CONTENT_LENGTH'] > $post_size) {
             throw new MyRadioException(
-                'The content uploaded in this form was too large for the server\'s configuration.',
+                "The content uploaded in this form was too large for the server's configuration.",
                 500
             );
         }

--- a/src/Classes/MyRadio/MyRadioForm.php
+++ b/src/Classes/MyRadio/MyRadioForm.php
@@ -2,7 +2,7 @@
 
 namespace MyRadio\MyRadio;
 
-use MyRadio\CoreUtils;
+use MyRadio\MyRadio\CoreUtils;
 use MyRadio\MyRadioException;
 use MyRadio\Config;
 

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -611,7 +611,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
      *
      * @param MyRadio_Show $show
      */
-    public function setShow($show)
+    public function setShow(MyRadio_Show $show)
     {
         self::$db->query(
             'DELETE FROM schedule.show_podcast_link
@@ -620,16 +620,12 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         );
 
         if (!empty($show)) {
-            if ($show instanceof MyRadio_Show) {
-                self::$db->query(
-                    'INSERT INTO schedule.show_podcast_link
-                    (show_id, podcast_id) VALUES ($1, $2)',
-                    [$show->getID(), $this->getID()]
-                );
-                $this->show_id = $show->getID();
-            } else {
-                throw new MyRadioException("The parameter provided is not a MyRadio_Show instance.", 500);
-            }
+            self::$db->query(
+                'INSERT INTO schedule.show_podcast_link
+                (show_id, podcast_id) VALUES ($1, $2)',
+                [$show->getID(), $this->getID()]
+            );
+            $this->show_id = $show->getID();
         } else {
             $this->show_id = null;
         }

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -611,7 +611,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
      *
      * @param MyRadio_Show $show
      */
-    public function setShow(MyRadio_Show $show)
+    public function setShow($show)
     {
         self::$db->query(
             'DELETE FROM schedule.show_podcast_link
@@ -620,12 +620,16 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         );
 
         if (!empty($show)) {
-            self::$db->query(
-                'INSERT INTO schedule.show_podcast_link
-                (show_id, podcast_id) VALUES ($1, $2)',
-                [$show->getID(), $this->getID()]
-            );
-            $this->show_id = $show->getID();
+            if ($show instanceof MyRadio_Show) {
+                self::$db->query(
+                    'INSERT INTO schedule.show_podcast_link
+                    (show_id, podcast_id) VALUES ($1, $2)',
+                    [$show->getID(), $this->getID()]
+                );
+                $this->show_id = $show->getID();
+            } else {
+                throw new MyRadioException("The parameter provided is not a MyRadio_Show instance.", 500);
+            }
         } else {
             $this->show_id = null;
         }

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -246,7 +246,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 MyRadioFormField::TYPE_TEXT,
                 [
                     'label' => 'Tags',
-                    'explanation' => 'A set of keywords to describe your podcast generally, seperated with spaces.',
+                    'explanation' => 'A set of keywords to describe your podcast generally, seperated with commas.',
                 ]
             )
         );
@@ -370,7 +370,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 [
                     'title' => $this->getMeta('title'),
                     'description' => $this->getMeta('description'),
-                    'tags' => is_null($this->getMeta('tag')) ? null : implode(' ', $this->getMeta('tag')),
+                    'tags' => is_null($this->getMeta('tag')) ? null : implode(',', $this->getMeta('tag')),
                     'show' => empty($this->show_id) ? null : $this->show_id,
                     'credits.member' => array_map(
                         function ($credit) {
@@ -408,6 +408,10 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         MyRadio_Show $show = null,
         $credits = null
     ) {
+        //Validate the tags
+        $tags = CoreUtils::explodeTags($tags);
+
+        self::$db->query('BEGIN');
 
         //Get an ID for the new Podcast
         $id = (int) self::$db->fetchColumn(
@@ -416,6 +420,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             .'RETURNING podcast_id',
             [MyRadio_User::getInstance()->getID()]
         )[0];
+
+        self::$db->query('COMMIT');
 
         $podcast = self::getInstance($id);
 
@@ -605,7 +611,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
      *
      * @param MyRadio_Show $show
      */
-    public function setShow(MyRadio_Show $show)
+    public function setShow($show)
     {
         self::$db->query(
             'DELETE FROM schedule.show_podcast_link
@@ -614,12 +620,16 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         );
 
         if (!empty($show)) {
-            self::$db->query(
-                'INSERT INTO schedule.show_podcast_link
-                (show_id, podcast_id) VALUES ($1, $2)',
-                [$show->getID(), $this->getID()]
-            );
-            $this->show_id = $show->getID();
+            if ($show instanceof MyRadio_Show) {
+                self::$db->query(
+                    'INSERT INTO schedule.show_podcast_link
+                    (show_id, podcast_id) VALUES ($1, $2)',
+                    [$show->getID(), $this->getID()]
+                );
+                $this->show_id = $show->getID();
+            } else {
+                throw new MyRadioException("The parameter provided is not a MyRadio_Show instance.", 500);
+            }
         } else {
             $this->show_id = null;
         }

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -370,7 +370,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 [
                     'title' => $this->getMeta('title'),
                     'description' => $this->getMeta('description'),
-                    'tags' => is_null($this->getMeta('tag')) ? null : implode(',', $this->getMeta('tag')),
+                    'tags' => is_null($this->getMeta('tag')) ? null : implode(', ', $this->getMeta('tag')),
                     'show' => empty($this->show_id) ? null : $this->show_id,
                     'credits.member' => array_map(
                         function ($credit) {

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -169,6 +169,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                 throw new MyRadioException('Parameter '.$field.' was not provided.', 400);
             }
         }
+        $tags = (!empty($params['tags'])) ? CoreUtils::explodeTags($params['tags']) : [];
 
         /**
          * Select an appropriate value for $term_id.
@@ -256,32 +257,18 @@ class MyRadio_Season extends MyRadio_Metadata_Common
         }
 
         //Same with tags
-        if (!empty($params['tags'])) {
-            // Explode the tags
-            // We want to handle the case when people delimit with commas, spaces, or commas and
-            // spaces, as well as handling extended spaces.
-            $tags = preg_split('/[, ] */', $params['tags'], null, PREG_SPLIT_NO_EMPTY);
-            foreach ($tags as $tag) {
-                if (empty($tag)) {
-                    continue;
-                }
-                self::$db->query(
-                    'INSERT INTO schedule.season_metadata
-                    (metadata_key_id, show_season_id, metadata_value, effective_from, memberid, approvedid)
-                    VALUES ($1, $2, $3, NOW(), $4, $4)',
-                    [
-                        self::getMetadataKey('tag'),
-                        $season_id,
-                        $tag,
-                        MyRadio_User::getInstance()->getID(),
-                    ]
-                );
-                if (strlen($tag) > 24){
-                    self::$db->query('ABORT');
-                    throw new MyRadioException('Sorry, individual tags longer than 24 characters
-                        aren\'t allowed. Please try again.', 400);
-                }
-            }
+        foreach ($tags as $tag) {
+            self::$db->query(
+                'INSERT INTO schedule.season_metadata
+                (metadata_key_id, show_season_id, metadata_value, effective_from, memberid, approvedid)
+                VALUES ($1, $2, $3, NOW(), $4, $4)',
+                [
+                    self::getMetadataKey('tag'),
+                    $season_id,
+                    $tag,
+                    MyRadio_User::getInstance()->getID(),
+                ]
+            );
         }
 
         //Actually commit the show to the database!

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -264,19 +264,19 @@ class MyRadio_Season extends MyRadio_Metadata_Common
             foreach ($tags as $tag) {
                 if (empty($tag)) {
                     continue;
-                } else if (strlen($tag) < 25) {
-                    self::$db->query(
-                        'INSERT INTO schedule.season_metadata
-                        (metadata_key_id, show_season_id, metadata_value, effective_from, memberid, approvedid)
-                        VALUES ($1, $2, $3, NOW(), $4, $4)',
-                        [
-                            self::getMetadataKey('tag'),
-                            $season_id,
-                            $tag,
-                            MyRadio_User::getInstance()->getID(),
-                        ]
-                    );
-                } else {
+                }
+                self::$db->query(
+                    'INSERT INTO schedule.season_metadata
+                    (metadata_key_id, show_season_id, metadata_value, effective_from, memberid, approvedid)
+                    VALUES ($1, $2, $3, NOW(), $4, $4)',
+                    [
+                        self::getMetadataKey('tag'),
+                        $season_id,
+                        $tag,
+                        MyRadio_User::getInstance()->getID(),
+                    ]
+                );
+                if (strlen($tag) > 24){
                     self::$db->query('ABORT');
                     throw new MyRadioException('Sorry, individual tags longer than 24 characters
                         aren\'t allowed. Please try again.', 400);

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -395,7 +395,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                 $this->getID(),
                 [
                     'description' => $this->getMeta('description'),
-                    'tags' => implode(',', $this->getMeta('tag')),
+                    'tags' => implode(', ', $this->getMeta('tag')),
                 ]
             );
     }

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -438,13 +438,14 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                 'credits',
                 MyRadioFormField::TYPE_TABULARSET,
                 [
+                    'label' => 'Credits',
                     'options' => [
                         new MyRadioFormField(
                             'memberid',
                             MyRadioFormField::TYPE_MEMBER,
                             [
                                 'explanation' => '',
-                                'label' => 'Credit',
+                                'label' => 'Member Name',
                             ]
                         ),
                         new MyRadioFormField(

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -292,8 +292,10 @@ class MyRadio_Show extends MyRadio_Metadata_Common
             );
         }
 
-        //Explode the tags
-        $tags = explode(' ', $params['tags']);
+        // Explode the tags
+        // We want to handle the case when people delimit with commas, spaces, or commas and
+        // spaces, as well as handling extended spaces.
+        $tags = preg_split('/[, ] */', $params['tags'], null, PREG_SPLIT_NO_EMPTY);
         foreach ($tags as $tag) {
             if (strlen($tag) < 25) {
                 self::$db->query(
@@ -424,7 +426,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                 MyRadioFormField::TYPE_TEXT,
                 [
                     'label' => 'Tags',
-                    'explanation' => 'A set of keywords to describe your show generally, seperated with spaces.',
+                    'explanation' => 'A set of keywords to describe your show generally, seperated with commas.',
                 ]
             )
         )->addField(
@@ -486,7 +488,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                     'title' => $this->getMeta('title'),
                     'description' => $this->getMeta('description'),
                     'genres' => $this->getGenre(),
-                    'tags' => is_null($this->getMeta('tag')) ? null : implode(' ', $this->getMeta('tag')),
+                    'tags' => is_null($this->getMeta('tag')) ? null : implode(',', $this->getMeta('tag')),
                     'credits.memberid' => array_map(
                         function ($ar) {
                             return $ar['User'];

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -295,13 +295,19 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         //Explode the tags
         $tags = explode(' ', $params['tags']);
         foreach ($tags as $tag) {
-            self::$db->query(
-                'INSERT INTO schedule.show_metadata
-                (metadata_key_id, show_id, metadata_value, effective_from, memberid, approvedid)
-                VALUES ($1, $2, $3, NOW(), $4, $4)',
-                [self::getMetadataKey('tag'), $show_id, $tag, $creator],
-                true
-            );
+            if (strlen($tag) < 25) {
+                self::$db->query(
+                    'INSERT INTO schedule.show_metadata
+                    (metadata_key_id, show_id, metadata_value, effective_from, memberid, approvedid)
+                    VALUES ($1, $2, $3, NOW(), $4, $4)',
+                    [self::getMetadataKey('tag'), $show_id, $tag, $creator],
+                    true
+                );
+            } else {
+                self::$db->query('ABORT');
+                throw new MyRadioException('Sorry, individual tags longer than 24 characters
+                    aren\'t allowed. Please try again.', 400);
+            }
         }
 
         //Set a location

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -293,9 +293,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         }
 
         // Explode the tags
-        // We want to handle the case when people delimit with commas, spaces, or commas and
-        // spaces, as well as handling extended spaces.
-        $tags = preg_split('/[, ] */', $params['tags'], null, PREG_SPLIT_NO_EMPTY);
+        $tags = CoreUtils::explodeTags($params['tags']);
         foreach ($tags as $tag) {
             self::$db->query(
                 'INSERT INTO schedule.show_metadata
@@ -304,11 +302,6 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                 [self::getMetadataKey('tag'), $show_id, $tag, $creator],
                 true
             );
-            if (strlen($tag) > 24) {
-                self::$db->query('ABORT');
-                throw new MyRadioException('Sorry, individual tags longer than 24 characters
-                    aren\'t allowed. Please try again.', 400);
-            }
         }
 
         //Set a location

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -481,7 +481,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                     'title' => $this->getMeta('title'),
                     'description' => $this->getMeta('description'),
                     'genres' => $this->getGenre(),
-                    'tags' => is_null($this->getMeta('tag')) ? null : implode(',', $this->getMeta('tag')),
+                    'tags' => is_null($this->getMeta('tag')) ? null : implode(', ', $this->getMeta('tag')),
                     'credits.memberid' => array_map(
                         function ($ar) {
                             return $ar['User'];

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -297,15 +297,14 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         // spaces, as well as handling extended spaces.
         $tags = preg_split('/[, ] */', $params['tags'], null, PREG_SPLIT_NO_EMPTY);
         foreach ($tags as $tag) {
-            if (strlen($tag) < 25) {
-                self::$db->query(
-                    'INSERT INTO schedule.show_metadata
-                    (metadata_key_id, show_id, metadata_value, effective_from, memberid, approvedid)
-                    VALUES ($1, $2, $3, NOW(), $4, $4)',
-                    [self::getMetadataKey('tag'), $show_id, $tag, $creator],
-                    true
-                );
-            } else {
+            self::$db->query(
+                'INSERT INTO schedule.show_metadata
+                (metadata_key_id, show_id, metadata_value, effective_from, memberid, approvedid)
+                VALUES ($1, $2, $3, NOW(), $4, $4)',
+                [self::getMetadataKey('tag'), $show_id, $tag, $creator],
+                true
+            );
+            if (strlen($tag) > 24) {
                 self::$db->query('ABORT');
                 throw new MyRadioException('Sorry, individual tags longer than 24 characters
                     aren\'t allowed. Please try again.', 400);

--- a/src/Controllers/Podcast/editPodcast.php
+++ b/src/Controllers/Podcast/editPodcast.php
@@ -54,7 +54,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         throw new MyRadioException('You must provide either an existing or new cover photo.', 400);
     }
 
-    URLUtils::redirectWithMessage($return_message, "Podcast", "default");
+    URLUtils::redirectWithMessage("Podcast", "default", $return_message);
 } else {
     //Not Submitted
     if (isset($_REQUEST['podcast_id'])) {

--- a/src/Controllers/Podcast/editPodcast.php
+++ b/src/Controllers/Podcast/editPodcast.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $podcast = MyRadio_Podcast::create(
             $data['title'],
             $data['description'],
-            explode(' ', $data['tags']),
+            $data['tags'],
             $data['file']['tmp_name'],
             empty($data['show']) ? null : MyRadio_Show::getInstance($data['show']),
             $data['credits']
@@ -34,7 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $podcast->setMeta('title', $data['title'])
             ->setMeta('description', $data['description'])
-            ->setMeta('tag', explode(' ', $data['tags']))
+            ->setMeta('tag', CoreUtils::explodeTags($data['tags']))
             ->setCredits($data['credits']['member'], $data['credits']['credittype']);
 
         if (!empty($data['show'])) {

--- a/src/Controllers/Podcast/editPodcast.php
+++ b/src/Controllers/Podcast/editPodcast.php
@@ -4,6 +4,7 @@
  */
 use \MyRadio\MyRadioException;
 use \MyRadio\MyRadio\AuthUtils;
+use \MyRadio\MyRadio\CoreUtils;
 use \MyRadio\MyRadio\URLUtils;
 use \MyRadio\ServiceAPI\MyRadio_Podcast;
 use \MyRadio\ServiceAPI\MyRadio_Show;

--- a/src/Controllers/Scheduler/editSeason.php
+++ b/src/Controllers/Scheduler/editSeason.php
@@ -17,7 +17,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($data['id'])) {
         //create new
         MyRadio_Season::create($data);
-        URLUtils::redirectWithMessage('Scheduler', 'myShows', 'Your new season has been created. You should recieve an email when it\'s scheduled!');
+        URLUtils::redirectWithMessage(
+            'Scheduler',
+            'myShows',
+            'Your new season has been created. You should recieve an email when it\'s scheduled!'
+        );
     } else {
         //submit edit
         $season = MyRadio_Season::getInstance($data['id']);

--- a/src/Controllers/Scheduler/editSeason.php
+++ b/src/Controllers/Scheduler/editSeason.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($data['id'])) {
         //create new
         MyRadio_Season::create($data);
-        URLUtils::redirectWithMessage('Scheduler', 'myShows', 'Season created!');
+        URLUtils::redirectWithMessage('Scheduler', 'myShows', 'Your new season has been created. You should recieve an email when it\'s scheduled!');
     } else {
         //submit edit
         $season = MyRadio_Season::getInstance($data['id']);

--- a/src/Controllers/Scheduler/editSeason.php
+++ b/src/Controllers/Scheduler/editSeason.php
@@ -20,7 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         URLUtils::redirectWithMessage(
             'Scheduler',
             'myShows',
-            'Your new season has been created. You should recieve an email when it\'s scheduled!'
+            "Your new season has been created. You should recieve an email when it's scheduled!"
         );
     } else {
         //submit edit

--- a/src/Controllers/Scheduler/editShow.php
+++ b/src/Controllers/Scheduler/editShow.php
@@ -34,7 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $show->setMeta('title', $data['title']);
         $show->setMeta('description', $data['description']);
 
-        // We want to handle the case when people delimit with commas, or commas and
+        // We want to handle the case when people delimit with commas, spaces, or commas and
         // spaces, as well as handling extended spaces.
         $tags = preg_split('/[, ] */', $data['tags'], null, PREG_SPLIT_NO_EMPTY);
         foreach ($tags as $tag) {

--- a/src/Controllers/Scheduler/editShow.php
+++ b/src/Controllers/Scheduler/editShow.php
@@ -20,7 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         URLUtils::redirectWithMessage(
             'Scheduler',
             'myShows',
-            'Your show, ' . $show->getMeta('title') . ', has been created!'
+            'Your show, ' . $show->getMeta('title') . ', has been created. Now create a new season for it!'
         );
     } else {
         //submit edit

--- a/src/Controllers/Scheduler/editShow.php
+++ b/src/Controllers/Scheduler/editShow.php
@@ -7,7 +7,6 @@
 use \MyRadio\MyRadio\AuthUtils;
 use \MyRadio\MyRadio\CoreUtils;
 use \MyRadio\MyRadio\URLUtils;
-use \MyRadio\MyRadioException;
 use \MyRadio\ServiceAPI\MyRadio_Show;
 use \MyRadio\ServiceAPI\MyRadio_User;
 
@@ -35,7 +34,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $show->setMeta('title', $data['title']);
         $show->setMeta('description', $data['description']);
 
-        //Explode the tags
         $show->setMeta(
             'tag',
             CoreUtils::explodeTags($data['tags'])

--- a/src/Controllers/Scheduler/editShow.php
+++ b/src/Controllers/Scheduler/editShow.php
@@ -6,6 +6,7 @@
  */
 use \MyRadio\MyRadio\AuthUtils;
 use \MyRadio\MyRadio\URLUtils;
+use \MyRadio\MyRadioException;
 use \MyRadio\ServiceAPI\MyRadio_Show;
 use \MyRadio\ServiceAPI\MyRadio_User;
 
@@ -35,9 +36,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         // We want to handle the case when people delimit with commas, or commas and
         // spaces, as well as handling extended spaces.
+        $tags = preg_split('/[, ] */', $data['tags'], null, PREG_SPLIT_NO_EMPTY);
+        foreach ($tags as $tag) {
+            if (strlen($tag) >= 25) {
+                throw new MyRadioException('Sorry, individual tags longer than 24 characters
+                    aren\'t allowed. Please try again.', 400);
+            }
+        }
         $show->setMeta(
             'tag',
-            preg_split('/[, ] */', $data['tags'], null, PREG_SPLIT_NO_EMPTY)
+            $tags
         );
 
         $show->setGenre($data['genres']);

--- a/src/Controllers/Scheduler/editShow.php
+++ b/src/Controllers/Scheduler/editShow.php
@@ -38,7 +38,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // spaces, as well as handling extended spaces.
         $tags = preg_split('/[, ] */', $data['tags'], null, PREG_SPLIT_NO_EMPTY);
         foreach ($tags as $tag) {
-            if (strlen($tag) >= 25) {
+            if (strlen($tag) > 24) {
                 throw new MyRadioException('Sorry, individual tags longer than 24 characters
                     aren\'t allowed. Please try again.', 400);
             }

--- a/src/Controllers/Scheduler/editShow.php
+++ b/src/Controllers/Scheduler/editShow.php
@@ -5,6 +5,7 @@
  * which should be the ID of the Show to edit.
  */
 use \MyRadio\MyRadio\AuthUtils;
+use \MyRadio\MyRadio\CoreUtils;
 use \MyRadio\MyRadio\URLUtils;
 use \MyRadio\MyRadioException;
 use \MyRadio\ServiceAPI\MyRadio_Show;
@@ -34,18 +35,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $show->setMeta('title', $data['title']);
         $show->setMeta('description', $data['description']);
 
-        // We want to handle the case when people delimit with commas, spaces, or commas and
-        // spaces, as well as handling extended spaces.
-        $tags = preg_split('/[, ] */', $data['tags'], null, PREG_SPLIT_NO_EMPTY);
-        foreach ($tags as $tag) {
-            if (strlen($tag) > 24) {
-                throw new MyRadioException('Sorry, individual tags longer than 24 characters
-                    aren\'t allowed. Please try again.', 400);
-            }
-        }
+        //Explode the tags
         $show->setMeta(
             'tag',
-            $tags
+            CoreUtils::explodeTags($data['tags'])
         );
 
         $show->setGenre($data['genres']);


### PR DESCRIPTION
Fixes #582
Fixes #751

2016-site has already implemented shortening via page overflow, but this forces each tag to be 24 chars or less (picked by @Danzibob to be nice looking).

- [x] Podcast changes incoming