### PR TITLE
BAPS-style auto start triggers

### DIFF
--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -5,12 +5,12 @@ html {
 body {
   width: 98%;
   min-width: 1200px;
-  height: calc(100% - 42px);
+  height: calc(100% - 5rem);
   margin: 20px auto 0 auto;
 }
 
 .main-container, #baps-channel-container {
-  height: calc(100% - 60px);
+  height: calc(100% - 11rem);
   width: 100%;
 }
 
@@ -347,3 +347,61 @@ select {
   cursor: pointer;
 }
 
+#baps-autocue-container {
+  width: 100%;
+  height: 10rem;
+  border: 2px solid #333;
+  margin: 1rem 0;
+  padding: .5rem 0 0 0;
+  position: relative;
+  cursor: default;
+  overflow: hidden;
+}
+
+.baps-autocue-outer {
+  width: 100%;
+  height: 2.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.baps-autocue-label {
+  display: inline-block;
+  position: absolute;
+  z-index: 20;
+}
+
+.baps-autocue-schedulebar {
+  position: absolute;
+  margin: 0;
+  padding: 0;
+  display: inline-block;
+  z-index: 10;
+  cursor: col-resize;
+}
+
+.baps-autocue-schedulebar .start {
+  position: absolute;
+  left: 1rem;
+  text-align: left;
+}
+
+.baps-autocue-schedulebar .end {
+  position: absolute;
+  right: 1rem;
+  text-align: right;
+}
+
+#baps-autocue-time {
+  position: absolute;
+  bottom: 0rem;
+  left: 7rem;
+}
+
+#baps-autocue-timebar {
+  position: absolute;
+  left: 45%;
+  top: -7.6rem;
+  height: 8rem;
+  border-left: 2px solid #0a5a9c;
+}

--- a/src/Public/js/nipsweb.init.js
+++ b/src/Public/js/nipsweb.init.js
@@ -4,11 +4,11 @@ var planner = null;
 $(document).ready(
   function () {
     planner = NIPSWeb(false); //If debug mode (stops reload)
-    planner.initialiseUI();
     planner.initialisePlayer("0");
     planner.initialisePlayer("1");
     planner.initialisePlayer("2");
     planner.initialisePlayer("3");
+    planner.initialiseUI();
     myradio.showAlert("Welcome to Show Planner!", "success");
   }
 );

--- a/src/Templates/NIPSWeb/main.twig
+++ b/src/Templates/NIPSWeb/main.twig
@@ -49,7 +49,7 @@
 
     </div>
 
-    <div id="baps-channelaction-container"  class="clearfix">
+    <div id="baps-channelaction-container" class="clearfix">
       {% set channels = [1, 2, 3, 'res'] %}
       {% for channel in channels %}
         <div class='box col-xs-3 baps-channel channel-footer{% if channel == 'res' %} library-footer{% endif %}'>
@@ -67,6 +67,17 @@
           <label id='ch{{channel}}-duration'>--:--</label>
         </div>
       {% endfor %}
+    </div>
+
+    <div id="baps-autocue-container" class="clearfix">
+      {% set channels = [1, 2, 3] %}
+      {% for channel in channels %}
+        <div class="baps-autocue-outer">
+          <div class="baps-autocue-label">Channel {{channel}}</div>
+          <div id="baps-autocue-schedulebar-{{channel}}" class="baps-autocue-schedulebar">&nbsp;<span class="start"></span><span class="end"></span></div>
+        </div>
+      {% endfor %}
+        <div id="baps-autocue-time"><span id="baps-autocue-time-display">--:--:--</span><span id="baps-autocue-timebar">&nbsp;</span></div>
     </div>
   </div>
 </div>
@@ -103,6 +114,7 @@
 
 {% block foot %}
 {{ parent() }}
+<script type="text/javascript" src="{{baseurl}}js/vendor/moment.min.js"></script>
 <script type="text/javascript" src="{{baseurl}}js/vendor/typeahead.bundle.min.js"></script>
 <script type="text/javascript" src="{{baseurl}}js/ul-sort.js"></script>
 <script type="text/javascript" src="{{baseurl}}js/nipsweb.channelconfig.js"></script>


### PR DESCRIPTION
 Initial support for the BAPS-style drag bars at the bottom of show planner. Might help raise awareness of the feature in BAPS itself. Currently very messy - mixture of JQ and raw JS usage, times don't update correctly whilst dragging, and there's a small jump on the first dragmove event, but it works.