### PR TITLE
Removed reference to studio 2

### DIFF
--- a/src/Menus/menu.json
+++ b/src/Menus/menu.json
@@ -77,7 +77,7 @@
                                     {
                                         "title": "Book Off-Air Studio",
                                         "url": "https://docs.google.com/a/yusu.org/spreadsheets/d/1tJ9E0laOPX-_nkWiPT9amDaliCWFRZENWDW51gLhTOM/edit?usp=sharing",
-                                        "description": "If you would like to use studio 2 we ask that you book the time you require. You can check availability and block out your required times here."
+                                        "description": "If you would like to use the off-air studio we ask that you book the time you require. You can check availability and block out your required times here."
                                     },
                                     {
                                         "title": "Apply for an Event",


### PR DESCRIPTION
This is a major change to the site functionality and may take several hours to review... 

- The description of Book Off-Air studio contained a reference to studio 2.