### PR TITLE
Prevent Importing expired/undigitised items into show plans.

### DIFF
--- a/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
+++ b/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
@@ -108,6 +108,32 @@ class NIPSWeb_ManagedItem extends \MyRadio\ServiceAPI\ServiceAPI
         return $this->length;
     }
 
+
+    /**
+     * Get the expiry date of the ManagedItem
+     *
+     * @return int Timestamp of expiry date.
+     */
+    public function getExpiryDate()
+    {
+        return $this->expirydate;
+    }
+
+    /**
+    * Get if the ManagedItem has expired.
+    *
+    * @return bool Has the item expired?
+    */
+    public function isExpired()
+    {
+        $expires = $this->getExpiryDate;
+        if ($expires != Null) {
+            return $expires <= strtotime("now");
+        } else {
+            return false;
+        }
+    }
+
     /**
      * Get the path of the ManagedItem.
      *
@@ -150,6 +176,8 @@ class NIPSWeb_ManagedItem extends \MyRadio\ServiceAPI\ServiceAPI
             'managedid' => $this->getID(),
             'length' => CoreUtils::intToTime($this->getLength() > 0 ? $this->getLength() : 0),
             'trackid' => $this->getID(),
+            'expirydate' => $this->getExpiryDate(),
+            'expired' => $this->isExpired(),
             'recordid' => 'ManagedDB', //Legacy NIPSWeb Views
             'auxid' => 'managed:'.$this->getID(), //Legacy NIPSWeb Views
         ];

--- a/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
+++ b/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
@@ -127,7 +127,7 @@ class NIPSWeb_ManagedItem extends \MyRadio\ServiceAPI\ServiceAPI
     public function isExpired()
     {
         $expires = $this->getExpiryDate();
-        if ($expires != NULL) {
+        if ($expires != null) {
             return $expires <= strtotime("now");
         } else {
             return false;

--- a/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
+++ b/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
@@ -127,7 +127,7 @@ class NIPSWeb_ManagedItem extends \MyRadio\ServiceAPI\ServiceAPI
     public function isExpired()
     {
         $expires = $this->getExpiryDate();
-        if ($expires != Null) {
+        if ($expires != NULL) {
             return $expires <= strtotime("now");
         } else {
             return false;

--- a/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
+++ b/src/Classes/NIPSWeb/NIPSWeb_ManagedItem.php
@@ -126,7 +126,7 @@ class NIPSWeb_ManagedItem extends \MyRadio\ServiceAPI\ServiceAPI
     */
     public function isExpired()
     {
-        $expires = $this->getExpiryDate;
+        $expires = $this->getExpiryDate();
         if ($expires != Null) {
             return $expires <= strtotime("now");
         } else {

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -342,6 +342,7 @@ select {
 }
 #import-channel-list li.disabled {
   background: lightpink;
+  padding-left: 5px;
 }
 #import-channel-list input[type=checkbox] {
   margin-right: 5px;

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -337,6 +337,12 @@ select {
 #import-channel-list p {
   margin: 0 20px;
 }
+#import-channel-list li {
+  list-style: none;
+}
+#import-channel-list li.disabled {
+  background: lightpink;
+}
 #import-channel-list input[type=checkbox] {
   margin-right: 5px;
 }

--- a/src/Public/css/planner.css
+++ b/src/Public/css/planner.css
@@ -339,10 +339,10 @@ select {
 }
 #import-channel-list li {
   list-style: none;
+  padding-left: 5px;
 }
 #import-channel-list li.disabled {
   background: lightpink;
-  padding-left: 5px;
 }
 #import-channel-list input[type=checkbox] {
   margin-right: 5px;

--- a/src/Public/js/nipsweb.import.js
+++ b/src/Public/js/nipsweb.import.js
@@ -161,7 +161,7 @@ function loadChannelList() {
           itemid = data.payload[selectedChannelNo][item]["album"].recordid + "-" + data.payload[selectedChannelNo][item].trackid;
         } else {
           cleanStars = "";
-          extraString = "";
+          extraString = "(" + data.payload[selectedChannelNo][item].length + ")";
           itemid = "ManagedDB-" + data.payload[selectedChannelNo][item].managedid;
           expired = data.payload[selectedChannelNo][item].expired;
         }

--- a/src/Public/js/nipsweb.import.js
+++ b/src/Public/js/nipsweb.import.js
@@ -142,6 +142,7 @@ function loadShowPlan() {
   var selectedTimeslotID = $("#import-timeslot-selector").find(":selected").attr("value");
   myradio.callAPI("GET", "timeslot", "showplan", selectedTimeslotID, "", "",
     function (data) {
+      var item;
       for (item in data) {
         if (item === "myradio_errors") {
           continue;

--- a/src/Public/js/nipsweb.import.js
+++ b/src/Public/js/nipsweb.import.js
@@ -148,7 +148,7 @@ function loadChannelList() {
       }
       $("#import-channel-list").empty();
       var selectedChannelNo = $("#import-channel-selector a.active").attr("channel");
-      var item, itemid, cleanStars, extraString;
+      var item, itemid, cleanStars, extraString, expired, disabled;
       for (item in data.payload[selectedChannelNo]) {
         if (data.payload[selectedChannelNo][item].type == "central") {
           if (!data.payload[selectedChannelNo][item].clean) {
@@ -156,14 +156,19 @@ function loadChannelList() {
           } else {
             cleanStars = "";
           }
+          expired = !(data.payload[selectedChannelNo][item].digitised);
           extraString = " - " + data.payload[selectedChannelNo][item].artist + " - " + data.payload[selectedChannelNo][item].album.title + " (" + data.payload[selectedChannelNo][item].length + ")";
           itemid = data.payload[selectedChannelNo][item]["album"].recordid + "-" + data.payload[selectedChannelNo][item].trackid;
         } else {
           cleanStars = "";
           extraString = "";
           itemid = "ManagedDB-" + data.payload[selectedChannelNo][item].managedid;
+          expired = data.payload[selectedChannelNo][item].expired;
         }
-        $("#import-channel-list").append("<input type=\"checkbox\" class=\"channel-list-item\" value=\""+ itemid + "\">" + cleanStars + data.payload[selectedChannelNo][item].title + extraString + "<br>");
+        disabled = (expired ? "disabled": "");
+        $("#import-channel-list").append("<li class=\"" + disabled + "\"><input type=\"checkbox\" class=\"channel-list-item\" "
+          + disabled + " value=\""+ itemid + "\">"
+          + cleanStars + data.payload[selectedChannelNo][item].title + extraString + "</li>");
         $("#import-channel-filter-btns").fadeIn();
       }
       if (data.payload[selectedChannelNo] == undefined || data.payload[selectedChannelNo].length == 0) {

--- a/src/Public/js/nipsweb.import.js
+++ b/src/Public/js/nipsweb.import.js
@@ -12,6 +12,7 @@ $.urlParam = function(name){
 var nextWeightChannel0;
 var nextWeightChannel1;
 var nextWeightChannel2;
+var currentShowPlan;
 
 $(document).ready(
   function () {
@@ -113,7 +114,7 @@ function updateTimeslotList() {
           //If we've only got one timeslot, select that automatically.
           if (data.payload.length == 1 ) {
             $("#import-timeslot-selector option").last().prop("selected",true);
-            loadChannelList();
+            loadShowPlan();
             $("#import-showplan").fadeIn();
           }
         } else {
@@ -133,50 +134,56 @@ function updateTimeslotList() {
 
 // Stage 4) Select the timeslot & load the showplan from it.
 $("#import-timeslot-selector").change(function() {
-  loadChannelList();
+  loadShowPlan();
   $("#import-showplan").fadeIn();
 });
 
-function loadChannelList() {
+function loadShowPlan() {
   var selectedTimeslotID = $("#import-timeslot-selector").find(":selected").attr("value");
-  myradio.callAPI("GET","timeslot","showplan",selectedTimeslotID,"","",
+  myradio.callAPI("GET", "timeslot", "showplan", selectedTimeslotID, "", "",
     function (data) {
       for (item in data) {
         if (item === "myradio_errors") {
           continue;
         }
       }
-      $("#import-channel-list").empty();
-      var selectedChannelNo = $("#import-channel-selector a.active").attr("channel");
-      var item, itemid, cleanStars, extraString, expired, disabled;
-      for (item in data.payload[selectedChannelNo]) {
-        if (data.payload[selectedChannelNo][item].type == "central") {
-          if (!data.payload[selectedChannelNo][item].clean) {
-            cleanStars = "**";
-          } else {
-            cleanStars = "";
-          }
-          expired = !(data.payload[selectedChannelNo][item].digitised);
-          extraString = " - " + data.payload[selectedChannelNo][item].artist + " - " + data.payload[selectedChannelNo][item].album.title + " (" + data.payload[selectedChannelNo][item].length + ")";
-          itemid = data.payload[selectedChannelNo][item]["album"].recordid + "-" + data.payload[selectedChannelNo][item].trackid;
+      currentShowPlan = data.payload;
+      loadChannelList();
+    });
+}
+
+function loadChannelList() {
+  $("#import-channel-list").empty();
+  var selectedChannelNo = $("#import-channel-selector a.active").attr("channel");
+  var item, itemid, cleanStars, extraString, expired, disabled;
+  if (currentShowPlan[selectedChannelNo] == undefined || currentShowPlan[selectedChannelNo].length == 0) {
+    $("#import-channel-list").append("<p>No items in this channel.</p>");
+    $("#import-channel-filter-btns").fadeOut();
+  } else {
+    for (item in currentShowPlan[selectedChannelNo]) {
+      item = currentShowPlan[selectedChannelNo][item];
+      if (item.type == "central") {
+        if (!item.clean) {
+          cleanStars = "**";
         } else {
           cleanStars = "";
-          extraString = "(" + data.payload[selectedChannelNo][item].length + ")";
-          itemid = "ManagedDB-" + data.payload[selectedChannelNo][item].managedid;
-          expired = data.payload[selectedChannelNo][item].expired;
         }
-        disabled = (expired ? "disabled": "");
-        $("#import-channel-list").append("<li class=\"" + disabled + "\"><input type=\"checkbox\" class=\"channel-list-item\" "
-          + disabled + " value=\""+ itemid + "\">"
-          + cleanStars + data.payload[selectedChannelNo][item].title + extraString + "</li>");
-        $("#import-channel-filter-btns").fadeIn();
+        expired = !(item.digitised);
+        extraString = " - " + item.artist + " - " + item.album.title + " (" + item.length + ")";
+        itemid = item["album"].recordid + "-" + item.trackid;
+      } else {
+        cleanStars = "";
+        extraString = " ";
+        itemid = "ManagedDB-" + item.managedid;
+        expired = item.expired;
       }
-      if (data.payload[selectedChannelNo] == undefined || data.payload[selectedChannelNo].length == 0) {
-        $("#import-channel-list").append("<p>No items in this channel.</p>");
-        $("#import-channel-filter-btns").fadeOut();
-      }
+      disabled = (expired ? "disabled": "");
+      $("#import-channel-list").append("<li class=\"" + disabled + "\"><input type=\"checkbox\" class=\"channel-list-item\" "
+        + disabled + " value=\""+ itemid + "\">"
+        + cleanStars + item.title + extraString + "</li>");
+      $("#import-channel-filter-btns").fadeIn();
     }
-  );
+  }
 }
 
 // Stage 5) Select a channel to import from.

--- a/src/Templates/NIPSWeb/import.twig
+++ b/src/Templates/NIPSWeb/import.twig
@@ -25,7 +25,7 @@
         <a href="#" onclick="selectNone()">Select None</a> |
         <a href="#" onclick="selectAll()">Select All</a>
         <br>
-        <span><strong>Please note:</strong> Items in red have been expired and may not be imported. These will show in red. If required, please find replacements after import.</span>
+        <span><strong>Please note:</strong> Items in red have been expired and may not be imported. If required, please find replacements after import.</span>
       </div>
 
       <form id="import-channel-list" class="baps-channel">

--- a/src/Templates/NIPSWeb/import.twig
+++ b/src/Templates/NIPSWeb/import.twig
@@ -24,7 +24,9 @@
       <div id="import-channel-filter-btns" class="hidden">
         <a href="#" onclick="selectNone()">Select None</a> |
         <a href="#" onclick="selectAll()">Select All</a>
+        <span><strong>Please note:</strong> Items that have expired or undigitied may not be imported. If required, please find replacements after importing other items.</span>
       </div>
+
       <form id="import-channel-list" class="baps-channel">
       </form>
       <div id="import-to-channel-selector">

--- a/src/Templates/NIPSWeb/import.twig
+++ b/src/Templates/NIPSWeb/import.twig
@@ -24,7 +24,8 @@
       <div id="import-channel-filter-btns" class="hidden">
         <a href="#" onclick="selectNone()">Select None</a> |
         <a href="#" onclick="selectAll()">Select All</a>
-        <span><strong>Please note:</strong> Items that have expired or undigitied may not be imported. If required, please find replacements after importing other items.</span>
+        <br>
+        <span><strong>Please note:</strong> Items in red have been expired and may not be imported. These will show in red. If required, please find replacements after import.</span>
       </div>
 
       <form id="import-channel-list" class="baps-channel">


### PR DESCRIPTION
Something that should have been there from the start (this has caused lots of people to play old jingles etc on shows because they continuously imported them from show to show).

Tested (and still running) on myradio-dev.