### PR TITLE
Fix show image caching bug.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -667,7 +667,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
             [$suffix, $result]
         );
         
-        $this->photo_url = $path;
+        $this->photo_url = Config::$public_media_uri.'/'.$suffix;
         $this->updateCacheObject();
     }
 


### PR DESCRIPTION
Somehow this state occurs where the incorrect show image URL including the server path gets cached. Clearing the cache would fix it as the show was _construct()'ed again.