### PR TITLE
Prevent broken email when browser wakes.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Webcam.php
+++ b/src/Classes/ServiceAPI/MyRadio_Webcam.php
@@ -19,7 +19,7 @@ class MyRadio_Webcam extends ServiceAPI
     public static function incrementViewCounter(MyRadio_User $user)
     {
         //Get the current view counter. We do this as a separate query in case the row doesn't exist yet
-        $counter = self::$db->fetchOne('SELECT timer FROM webcam.memberviews WHERE memberid = $1', [$user->getID()]);
+        $counter = self::getViewCounter($user);
         if (empty($counter)) {
             $counter = 0;
             $sql = 'INSERT INTO webcam.memberviews (memberid, timer) VALUES ($1, $2)';
@@ -31,6 +31,12 @@ class MyRadio_Webcam extends ServiceAPI
 
         self::$db->query($sql, [$user->getID(), $counter]);
 
+        return $counter;
+    }
+
+    public static function getViewCounter(MyRadio_User $user)
+    {
+        $counter = self::$db->fetchOne('SELECT timer FROM webcam.memberviews WHERE memberid = $1', [$user->getID()]);
         return $counter;
     }
 

--- a/src/Classes/ServiceAPI/MyRadio_Webcam.php
+++ b/src/Classes/ServiceAPI/MyRadio_Webcam.php
@@ -37,7 +37,7 @@ class MyRadio_Webcam extends ServiceAPI
     public static function getViewCounter(MyRadio_User $user)
     {
         $counter = self::$db->fetchOne('SELECT timer FROM webcam.memberviews WHERE memberid = $1', [$user->getID()]);
-        return $counter['timer'];
+        return $counter;
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_Webcam.php
+++ b/src/Classes/ServiceAPI/MyRadio_Webcam.php
@@ -37,7 +37,7 @@ class MyRadio_Webcam extends ServiceAPI
     public static function getViewCounter(MyRadio_User $user)
     {
         $counter = self::$db->fetchOne('SELECT timer FROM webcam.memberviews WHERE memberid = $1', [$user->getID()]);
-        return $counter;
+        return $counter['timer'];
     }
 
     /**

--- a/src/Controllers/Webcam/a-trackViewer.php
+++ b/src/Controllers/Webcam/a-trackViewer.php
@@ -8,11 +8,11 @@ use \MyRadio\ServiceAPI\MyRadio_Webcam;
 use \MyRadio\MyRadioException;
 
 if (isset($_SESSION['webcam_lastcounterincrement']) && $_SESSION['webcam_lastcounterincrement'] > time() - 10) {
-    // Occurs when browser wakes up and tries to spam all the missed updates.
-    throw new MyRadioException("The Webcam counter was last updated too recently, this request was ignored.", 400);
+    // Occurs when browser wakes up and tries to spam all the missed updates, or if multiple webcam pages are open.
+    $data = MyRadio_Webcam::getViewCounter(MyRadio_User::getInstance());
+} else {
+    $_SESSION['webcam_lastcounterincrement'] = time();
+    $data = MyRadio_Webcam::incrementViewCounter(MyRadio_User::getInstance());
 }
-$_SESSION['webcam_lastcounterincrement'] = time();
-
-$data = MyRadio_Webcam::incrementViewCounter(MyRadio_User::getInstance());
 
 URLUtils::dataToJSON($data);

--- a/src/Controllers/Webcam/a-trackViewer.php
+++ b/src/Controllers/Webcam/a-trackViewer.php
@@ -5,9 +5,11 @@
 use \MyRadio\MyRadio\URLUtils;
 use \MyRadio\ServiceAPI\MyRadio_User;
 use \MyRadio\ServiceAPI\MyRadio_Webcam;
+use \MyRadio\MyRadioException;
 
 if (isset($_SESSION['webcam_lastcounterincrement']) && $_SESSION['webcam_lastcounterincrement'] > time() - 10) {
-    require 'Controllers/Errors/400.php';
+    // Occurs when browser wakes up and tries to spam all the missed updates.
+    throw new MyRadioException("The Webcam counter was last updated too recently, this request was ingored.", 400);
 }
 $_SESSION['webcam_lastcounterincrement'] = time();
 

--- a/src/Controllers/Webcam/a-trackViewer.php
+++ b/src/Controllers/Webcam/a-trackViewer.php
@@ -9,7 +9,7 @@ use \MyRadio\MyRadioException;
 
 if (isset($_SESSION['webcam_lastcounterincrement']) && $_SESSION['webcam_lastcounterincrement'] > time() - 10) {
     // Occurs when browser wakes up and tries to spam all the missed updates.
-    throw new MyRadioException("The Webcam counter was last updated too recently, this request was ingored.", 400);
+    throw new MyRadioException("The Webcam counter was last updated too recently, this request was ignored.", 400);
 }
 $_SESSION['webcam_lastcounterincrement'] = time();
 

--- a/src/Controllers/Webcam/a-trackViewer.php
+++ b/src/Controllers/Webcam/a-trackViewer.php
@@ -9,7 +9,7 @@ use \MyRadio\MyRadioException;
 
 if (isset($_SESSION['webcam_lastcounterincrement']) && $_SESSION['webcam_lastcounterincrement'] > time() - 10) {
     // Occurs when browser wakes up and tries to spam all the missed updates, or if multiple webcam pages are open.
-    $data = MyRadio_Webcam::getViewCounter(MyRadio_User::getInstance());
+    $data = MyRadio_Webcam::getViewCounter(MyRadio_User::getInstance())["timer"];
 } else {
     $_SESSION['webcam_lastcounterincrement'] = time();
     $data = MyRadio_Webcam::incrementViewCounter(MyRadio_User::getInstance());

--- a/src/Public/js/myradio.webcam.tracker.js
+++ b/src/Public/js/myradio.webcam.tracker.js
@@ -12,10 +12,6 @@ function webcamTrackViewer() {
     type: "get",
     cache: false,
     url: myradio.makeURL("Webcam", "a-trackViewer"),
-    statusCode: {
-      // API returns 400 when timedelta is too big (minimised tab or whatever) clientside should ignore.
-      400: function () {}
-    },
     success: function (data) {
       var sub = 0;
       var time = "";
@@ -39,7 +35,7 @@ function webcamTrackViewer() {
         time = time + sub + " minutes, ";
         data -= sub*60;
       }
-      time = time + data + " seconds";
+      time = time + data + " seconds.";
       $("#webcam-time-counter-value").html(time);
     }
   });


### PR DESCRIPTION
No longer will we get a wall of HTML over email every time someone leaves the webcams page open and clicks "Report" on the Error popup model. Also was caused by having multiple webcam pages open.

