### PR TITLE
Allow emails to work if the user has URY email without server account.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -499,7 +499,13 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 //ffs, some people don't have an eduroam either.
                 $eduroam = $this->getEduroam();
                 if (empty($eduroam)) {
-                    return;
+                    if (!empty($this->email)) {
+                        //This is an email not associated to a user.
+                        return $this->email;
+                    } else {
+                        //Give up trying to send.
+                        return;
+                    }
                 } else {
                     return $eduroam.'@'.Config::$eduroam_domain;
                 }


### PR DESCRIPTION
Because having a user like computing@ury.org.uk does not allow myradio to email them.