### PR TITLE
Update messaging on podcast form fields

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -343,7 +343,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 [
                     'label' => 'Upload New Cover Photo',
                     'explanation' => 'If you haven\'t specified an existing cover photo, upload one '
-                    . 'here - should be 400x400 pixels.',
+                    . 'here - it should be square and at least 400x400 pixels.',
                     'required' => false,
                 ]
             )

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -342,7 +342,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 MyRadioFormField::TYPE_FILE,
                 [
                     'label' => 'Upload New Cover Photo',
-                    'explanation' => 'If you haven\'t specified an existing cover photo, upload one here - should be 400x400 pixels.',
+                    'explanation' => 'If you haven\'t specified an existing cover photo, upload one '
+                    . 'here - should be 400x400 pixels.',
                     'required' => false,
                 ]
             )
@@ -354,7 +355,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                     'label' => 'I have read and confirm that this audio file complies'
                     .' with <a href="/wiki/Podcasting_Policy" target="_blank">'
                     .Config::$short_name.'\'s Podcasting Policy</a>.',
-                    'explanation' => 'Once the podcast upload is complete, please notify the Computing Team in Slack as they may need to clear the cache. Thank you!'
+                    'explanation' => 'Once the podcast upload is complete, please notify the '
+                    . 'Computing Team in Slack as they may need to clear the cache. Thank you!'
                 ]
             )
         );

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -342,7 +342,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 MyRadioFormField::TYPE_FILE,
                 [
                     'label' => 'Upload New Cover Photo',
-                    'explanation' => 'If you haven\'t specified an existing cover photo, upload one here.',
+                    'explanation' => 'If you haven\'t specified an existing cover photo, upload one here - should be 400x400 pixels.',
                     'required' => false,
                 ]
             )
@@ -354,6 +354,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                     'label' => 'I have read and confirm that this audio file complies'
                     .' with <a href="/wiki/Podcasting_Policy" target="_blank">'
                     .Config::$short_name.'\'s Podcasting Policy</a>.',
+                    'explanation' => 'Once the podcast upload is complete, please notify the Computing Team in Slack as they may need to clear the cache. Thank you!'
                 ]
             )
         );


### PR DESCRIPTION
- clarify that image sizes should be 400x400px
- ask to notify Comp about cache breakage

Context (URY members only): https://ury.slack.com/archives/C091ZRR63/p1572298733002700