### PR TITLE
Limit SIS message length to 1k chars and fix logic error

### DIFF
--- a/src/Classes/SIS/SIS_Utils.php
+++ b/src/Classes/SIS/SIS_Utils.php
@@ -117,7 +117,7 @@ class SIS_Utils extends ServiceAPI
     public static function checkMessageSpam($message)
     {
         if (strlen($message) > 1000) {
-            return true;   
+            return true;
         }
         if (!empty(Config::$spam)) {
             foreach (Config::$spam as $needle) {

--- a/src/Classes/SIS/SIS_Utils.php
+++ b/src/Classes/SIS/SIS_Utils.php
@@ -117,7 +117,7 @@ class SIS_Utils extends ServiceAPI
     public static function checkMessageSpam($message)
     {
         if (strlen($message) > 1000) {
-         return true;   
+            return true;   
         }
         if (!empty(Config::$spam)) {
             foreach (Config::$spam as $needle) {

--- a/src/Classes/SIS/SIS_Utils.php
+++ b/src/Classes/SIS/SIS_Utils.php
@@ -116,14 +116,16 @@ class SIS_Utils extends ServiceAPI
      */
     public static function checkMessageSpam($message)
     {
+        if (strlen($message) > 1000) {
+         return true;   
+        }
         if (!empty(Config::$spam)) {
             foreach (Config::$spam as $needle) {
                 if (stripos($message, $needle) !== false) {
                     return true;
-                } else {
-                    return false;
                 }
             }
+            return false;
         } else {
             return false;
         }


### PR DESCRIPTION
No reasonable human is going to send more than a tweet's length anyway