### PR TITLE
Lock the showplanner if saving fails

### DIFF
--- a/src/Public/js/nipsweb.player.js
+++ b/src/Public/js/nipsweb.player.js
@@ -86,10 +86,12 @@ var NIPSWeb = function (d) {
                 $("ul.baps-channel li[timeslotitemid=\"findme\"]").attr("timeslotitemid", data.payload[i].timeslotitemid);
               }
               if (!data.payload[i].status) {
-                myradio.showAlert("Save failed! Reloading in 5 seconds.", "danger");
+                $(".baps-channel.ui-sortable").sortable("disable");
                 if (!debug) {
-                  $(".baps-channel.ui-sortable").sortable("disable");
+                  myradio.showAlert("Save failed! Reloading in 5 seconds.", "danger");
                   setTimeout(function(){ reload(); }, 5000);
+                } else {
+                  myradio.showAlert("Save failed! Debug mode, please reload manually.", "danger");
                 }
               } else {
                 myradio.showAlert("Changes Saved Successfully", "success");

--- a/src/Public/js/nipsweb.player.js
+++ b/src/Public/js/nipsweb.player.js
@@ -88,6 +88,7 @@ var NIPSWeb = function (d) {
               if (!data.payload[i].status) {
                 myradio.showAlert("Save failed! Reloading in 5 seconds.", "danger");
                 if (!debug) {
+                  $(".baps-channel.ui-sortable").sortable("disable")
                   setTimeout(function(){ reload(); }, 5000);
                 }
               } else {

--- a/src/Public/js/nipsweb.player.js
+++ b/src/Public/js/nipsweb.player.js
@@ -88,7 +88,7 @@ var NIPSWeb = function (d) {
               if (!data.payload[i].status) {
                 myradio.showAlert("Save failed! Reloading in 5 seconds.", "danger");
                 if (!debug) {
-                  $(".baps-channel.ui-sortable").sortable("disable")
+                  $(".baps-channel.ui-sortable").sortable("disable");
                   setTimeout(function(){ reload(); }, 5000);
                 }
               } else {


### PR DESCRIPTION
If a save fails, showplanner stops saving changes, but still lets users drag tracks around, which could potentially lead to them making changes that aren't saved. To ensure this doesn't happen, disable showplanner prior to reloading.