### PR TITLE
Moving show subtypes into MyRadio, part 6 - FINISH HIM

### DIFF
--- a/scripts/migrate-show-colours.php
+++ b/scripts/migrate-show-colours.php
@@ -20,7 +20,7 @@ while ($startOfBatch < $numShows) {
     Database::getInstance()->query('BEGIN');
     for ($i = $startOfBatch; $i < $startOfBatch + $batchSize; $i++) {
         $show = $shows[$i];
-        $subtype = CoreUtils::get_subtype_for_show($show->getMeta('title'));
+        $subtype = CoreUtils::getSubtypeForShow($show->getMeta('title'));
         Database::getInstance()->query('INSERT INTO schedule.show_season_subtype
             (show_id, show_subtype_id, effective_from)
             (SELECT $1, (SELECT show_subtype_id

--- a/src/Classes/MyRadio/CoreUtils.php
+++ b/src/Classes/MyRadio/CoreUtils.php
@@ -761,7 +761,8 @@ class CoreUtils
      * @param $show_name string
      * @return string
      */
-    public static function get_subtype_for_show($show_name) {
+    public static function getSubtypeForShow($show_name)
+    {
         $blockMatches = [
             ["ury: early morning", "primetime"],
             ["ury breakfast", "primetime"],
@@ -828,5 +829,4 @@ class CoreUtils
         }
         return 'regular';
     }
-
 }

--- a/src/Classes/ServiceAPI/MyRadio_Creditable.php
+++ b/src/Classes/ServiceAPI/MyRadio_Creditable.php
@@ -28,7 +28,7 @@ trait MyRadio_Creditable
      *
      * @return type
      */
-    public function getCredits(MyRadio\ServiceAPI\MyRadio_Metadata_Common $parent = null)
+    public function getCredits(\MyRadio\ServiceAPI\MyRadio_Metadata_Common $parent = null)
     {
         $parent = empty($parent) ? [] : $parent->getCredits();
         $current = empty($this->credits) ? [] : $this->credits;

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -418,7 +418,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                         ),
                         'label' => 'Subtype',
                         'explanation' => 'If necessary, override the subtype for this season. '
-                            .'If you\'re not sure what you\'re doing, leave it what it is.',
+                            .'If you\'re not sure what you\'re doing, leave it as it is.',
                         'required' => false
                     ]
             )

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -694,7 +694,7 @@ EOT
      * @param parent Unused for type compatibility with parent
      * @return array[]
      */
-    public function getCredits(MyRadio\ServiceAPI\MyRadio_Metadata_Common $parent = null)
+    public function getCredits(\MyRadio\ServiceAPI\MyRadio_Metadata_Common $parent = null)
     {
         return parent::getCredits($this->getShow());
     }

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -435,6 +435,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
             ->editMode(
                 $this->getID(),
                 [
+                    'show_id' => $this->show_id,
                     'description' => $this->getMeta('description'),
                     'tags' => implode(', ', $this->getMeta('tag')),
                     'subtype' => $showSubtype === $seasonSubtype ? '' : $seasonSubtype

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -584,6 +584,14 @@ class MyRadio_Season extends MyRadio_Metadata_Common
         );
     }
 
+    public function setCredits($users, $credittypes, $table = null, $pkey = null)
+    {
+        $r = parent::setCredits($users, $credittypes, 'schedule.season_credit', 'season_id');
+        $this->updateCacheObject();
+
+        return $r;
+    }
+
     /**
      * Get a list of all Seasons that were for the current term, or
      * if we are not currently in a Term, the most recenly finished term.

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -287,7 +287,9 @@ class MyRadio_Season extends MyRadio_Metadata_Common
             self::$db->query(
                 'INSERT INTO schedule.show_season_subtype
                 (season_id, show_subtype_id, effective_from)
-                VALUES ($1, (SELECT show_subtype_id FROM schedule.show_subtypes WHERE show_subtypes.class = $2), NOW())',
+                VALUES ($1, (
+                    SELECT show_subtype_id FROM schedule.show_subtypes WHERE show_subtypes.class = $2
+                    ), NOW())',
                 [
                     $season_id,
                     $params['subtype']
@@ -404,13 +406,14 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                 ]
             )
         )->addField(
-                new MyRadioFormField(
-                    'subtype',
-                    MyRadioFormField::TYPE_SELECT,
-                    [
-                        'options' => array_merge([
+            new MyRadioFormField(
+                'subtype',
+                MyRadioFormField::TYPE_SELECT,
+                [
+                        'options' => array_merge(
+                            [
                             ['value' => '', 'text' => 'Leave unchanged']
-                        ],
+                            ],
                             MyRadio_ShowSubtype::getOptions()
                         ),
                         'label' => 'Subtype',
@@ -418,8 +421,8 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                             .'If you\'re not sure what you\'re doing, leave it what it is.',
                         'required' => false
                     ]
-                )
-            )->addField(
+            )
+        )->addField(
             new MyRadioFormField(
                 'grp-adv_close',
                 MyRadioFormField::TYPE_SECTION_CLOSE
@@ -761,7 +764,8 @@ EOT
      * Gets the subtype for this season.
      * @return MyRadio_ShowSubtype
      */
-    public function getSubtype() {
+    public function getSubtype()
+    {
         if ($this->subtype_id === null) {
             return $this->getShow()->getSubtype();
         }
@@ -774,7 +778,8 @@ EOT
      * @todo support effectiveFrom and effectiveTo
      * @param $subtypeId
      */
-    public function setSubtype($subtypeId) {
+    public function setSubtype($subtypeId)
+    {
         self::$db->query('UPDATE schedule.show_season_subtype SET show_subtype_id = $1 WHERE season_id = $1', [
             $subtypeId, $this->season_id
         ]);
@@ -784,7 +789,8 @@ EOT
      * Sets this season's subtype by the subtype name.
      * @param $subtypeName
      */
-    public function setSubtypeByName($subtypeName) {
+    public function setSubtypeByName($subtypeName)
+    {
         self::$db->query(
             'UPDATE schedule.show_season_subtype
             SET show_subtype_id = subtype.show_subtype_id
@@ -797,7 +803,8 @@ EOT
     /**
      * Clears the subtype for this season, resetting it to the show's "main" subtype.
      */
-    public function clearSubtype() {
+    public function clearSubtype()
+    {
         self::$db->query('DELETE FROM schedule.show_season_subtype WHERE season_id = $1', [$this->season_id]);
     }
 

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -408,8 +408,9 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                     'subtype',
                     MyRadioFormField::TYPE_SELECT,
                     [
-                        'options' => array_merge(
-                            ['value' => '', 'text' => 'Leave unchanged'],
+                        'options' => array_merge([
+                            ['value' => '', 'text' => 'Leave unchanged']
+                        ],
                             MyRadio_ShowSubtype::getOptions()
                         ),
                         'label' => 'Subtype',

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -414,7 +414,8 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                         ),
                         'label' => 'Subtype',
                         'explanation' => 'If necessary, override the subtype for this season. '
-                            .'If you\'re not sure what you\'re doing, leave it what it is.'
+                            .'If you\'re not sure what you\'re doing, leave it what it is.',
+                        'required' => false
                     ]
                 )
             )->addField(

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -409,7 +409,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                     MyRadioFormField::TYPE_SELECT,
                     [
                         'options' => array_merge(
-                            ['value' => '', 'name' => 'Leave unchanged'],
+                            ['value' => '', 'text' => 'Leave unchanged'],
                             MyRadio_ShowSubtype::getOptions()
                         ),
                         'label' => 'Subtype',

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -434,6 +434,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                 [
                     'description' => $this->getMeta('description'),
                     'tags' => implode(', ', $this->getMeta('tag')),
+                    'subtype' => $this->getSubtype()->getClass(),
                 ]
             );
     }

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -428,6 +428,8 @@ class MyRadio_Season extends MyRadio_Metadata_Common
 
     public function getEditForm()
     {
+        $showSubtype = $this->getShow()->getSubtype()->getClass();
+        $seasonSubtype = $this->getSubtype()->getClass();
         return self::getForm()
             ->setSubTitle('Edit Season')
             ->editMode(
@@ -435,7 +437,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
                 [
                     'description' => $this->getMeta('description'),
                     'tags' => implode(', ', $this->getMeta('tag')),
-                    'subtype' => $this->getSubtype()->getClass(),
+                    'subtype' => $showSubtype === $seasonSubtype ? '' : $seasonSubtype
                 ]
             );
     }

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -334,22 +334,12 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         );
 
         // Subtype too
-        // TODO: kill this bodgy shit as soon as possible
-        if (!empty($params['subtype'])) {
-            self::$db->query(
-                'INSERT INTO schedule.show_season_subtype
-            (show_id, show_subtype_id, effective_from)
-            VALUES ($1, $2, NOW())',
-                [$show_id, $params['subtype']]
-            );
-        } else {
-            self::$db->query(
-                'INSERT INTO schedule.show_season_subtype
-            (show_id, show_subtype_id, effective_from)
-            (SELECT $1, (SELECT show_subtype_id FROM schedule.show_subtypes WHERE show_subtypes.class = $2), NOW())',
-                [$show_id, CoreUtils::get_subtype_for_show($params['title'])]
-            );
-        }
+        self::$db->query(
+            'INSERT INTO schedule.show_season_subtype
+        (show_id, show_subtype_id, effective_from)
+        VALUES ($1, (SELECT show_subtype_id FROM schedule.show_subtypes WHERE show_subtypes.class = $2), NOW())',
+            [$show_id, $params['subtype']]
+        );
 
         //And now all that's left is who's on the show
         for ($i = 0; $i < sizeof($params['credits']['memberid']); ++$i) {
@@ -437,6 +427,17 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                     ),
                     'label' => 'Genre',
                     'explanation' => 'What type of music do you play, if any?',
+                ]
+            )
+        )->addField(
+            new MyRadioFormField(
+                'subtype',
+                MyRadioFormField::TYPE_SELECT,
+                [
+                    'options' => MyRadio_ShowSubtype::getOptions(),
+                    'label' => 'Subtype',
+                    'explanation' => 'Select the subtype for this show (speech, music, news, etc.)'
+                    . 'If unsure, leave as Regular.'
                 ]
             )
         )->addField(

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -665,7 +665,8 @@ class MyRadio_Show extends MyRadio_Metadata_Common
      * Note that subtypes can be overridden per-season, so you should probably use MyRadio_Season->getSubtype().
      * @return MyRadio_ShowSubtype
      */
-    public function getSubtype() {
+    public function getSubtype()
+    {
         return MyRadio_ShowSubtype::getInstance($this->subtype_id);
     }
 
@@ -675,7 +676,8 @@ class MyRadio_Show extends MyRadio_Metadata_Common
      * @todo support effectiveFrom and effectiveTo
      * @param $subtypeId
      */
-    public function setSubtype($subtypeId) {
+    public function setSubtype($subtypeId)
+    {
         self::$db->query('UPDATE schedule.show_season_subtype SET show_subtype_id = $1 WHERE show_id = $1', [
             $subtypeId, $this->show_id
         ]);
@@ -685,7 +687,8 @@ class MyRadio_Show extends MyRadio_Metadata_Common
      * Sets this show's subtype by the subtype name.
      * @param $subtypeName
      */
-    public function setSubtypeByName($subtypeName) {
+    public function setSubtypeByName($subtypeName)
+    {
         self::$db->query(
             'UPDATE schedule.show_season_subtype
             SET show_subtype_id = subtype.show_subtype_id

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -437,7 +437,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                     'options' => MyRadio_ShowSubtype::getOptions(),
                     'label' => 'Subtype',
                     'explanation' => 'Select the subtype for this show (speech, music, news, etc.)'
-                    . 'If unsure, leave as Regular.'
+                    . ' If unsure, leave as Regular.'
                 ]
             )
         )->addField(
@@ -509,6 +509,7 @@ class MyRadio_Show extends MyRadio_Metadata_Common
                     'title' => $this->getMeta('title'),
                     'description' => $this->getMeta('description'),
                     'genres' => $this->getGenre(),
+                    'subtype' => $this->getSubtype()->getClass(),
                     'tags' => is_null($this->getMeta('tag')) ? null : implode(', ', $this->getMeta('tag')),
                     'credits.memberid' => array_map(
                         function ($ar) {

--- a/src/Classes/ServiceAPI/MyRadio_ShowSubtype.php
+++ b/src/Classes/ServiceAPI/MyRadio_ShowSubtype.php
@@ -14,7 +14,8 @@ use MyRadio\MyRadioException;
  *
  * @uses    \Database
  */
-class MyRadio_ShowSubtype extends ServiceAPI {
+class MyRadio_ShowSubtype extends ServiceAPI
+{
     /**
      * The ID of this subtype
      * @var int
@@ -41,7 +42,8 @@ class MyRadio_ShowSubtype extends ServiceAPI {
         $this->class = $data['class'];
     }
 
-    public function getID() {
+    public function getID()
+    {
         return $this->show_subtype_id;
     }
 
@@ -50,7 +52,8 @@ class MyRadio_ShowSubtype extends ServiceAPI {
      * Get the name of this subtype.
      * @return string
      */
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
@@ -58,7 +61,8 @@ class MyRadio_ShowSubtype extends ServiceAPI {
      * Get the CSS class of this subtype.
      * @return string
      */
-    public function getClass() {
+    public function getClass()
+    {
         return $this->class;
     }
 
@@ -76,7 +80,8 @@ class MyRadio_ShowSubtype extends ServiceAPI {
      *
      * @return MyRadio_ShowSubtype[]
      */
-    public static function getAll() {
+    public static function getAll()
+    {
         $sql = 'SELECT show_subtype_id, name, class FROM schedule.show_subtypes';
         $rows = self::$db->fetchAll($sql);
 
@@ -92,8 +97,11 @@ class MyRadio_ShowSubtype extends ServiceAPI {
      * Get all subtypes in a format suitable for a MyRadioFormField select field.
      * @return array
      */
-    public static function getOptions() {
-        return self::$db->fetchAll('SELECT class AS value, name AS text FROM schedule.show_subtypes ORDER BY show_subtype_id ASC');
+    public static function getOptions()
+    {
+        return self::$db->fetchAll(
+            'SELECT class AS value, name AS text FROM schedule.show_subtypes ORDER BY show_subtype_id ASC'
+        );
     }
 
     protected static function factory($itemid)

--- a/src/Classes/ServiceAPI/MyRadio_ShowSubtype.php
+++ b/src/Classes/ServiceAPI/MyRadio_ShowSubtype.php
@@ -88,6 +88,14 @@ class MyRadio_ShowSubtype extends ServiceAPI {
         return CoreUtils::setToDataSource($subtypes);
     }
 
+    /**
+     * Get all subtypes in a format suitable for a MyRadioFormField select field.
+     * @return array
+     */
+    public static function getOptions() {
+        return self::$db->fetchAll('SELECT class AS value, name AS text FROM schedule.show_subtypes ORDER BY show_subtype_id ASC');
+    }
+
     protected static function factory($itemid)
     {
         $sql = 'SELECT show_subtype_id, name, class FROM schedule.show_subtypes WHERE show_subtype_id = $1 LIMIT 1';

--- a/src/Controllers/Scheduler/editSeason.php
+++ b/src/Controllers/Scheduler/editSeason.php
@@ -35,6 +35,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $season->setMeta('description', $data['description']);
         $season->setMeta('tag', explode(' ', $data['tags']));
         $season->setCredits($data['credits']['member'], $data['credits']['credittype']);
+        if (!empty($data['subtype'])) {
+            $season->setSubtypeByName($data['subtype']);
+        } else {
+            $season->clearSubtype();
+        }
 
         URLUtils::redirectWithMessage('Scheduler', 'listSeasons', 'Season updated!', ['seasonid' => $season->getID()]);
     }

--- a/src/Controllers/Scheduler/editShow.php
+++ b/src/Controllers/Scheduler/editShow.php
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $show->setMeta('upload_state', 'Opted Out');
         }
 
-        $show->setSubtypeByName(CoreUtils::get_subtype_for_show($data['title']));
+        $show->setSubtypeByName($data['subtype']);
 
         URLUtils::redirectWithMessage('Scheduler', 'myShows', 'Show Updated!');
     }


### PR DESCRIPTION
Hoo boy is this a crazy PR.

This is a big project, comprised of several PRs. See [here](https://github.com/orgs/UniversityRadioYork/teams/officers/discussions/1) for the plan (internal only). This PR is a continuation of https://github.com/UniversityRadioYork/2016-site/pull/212

In this PR, we finish the job by adding editing forms for subtypes in MyRadio.

As part of this, I also discovered that the season editing form is hopelessly broken. Some of the later commits in this series are me trying to unbreak it, fruitlessly. I might have another pop at it. Oh well, the show-level subtype logic works and is tested on dev.

Test Plan:
* Deploy to dev
* Check that creating a show works fine, including the subtype (i.e. it's returned in the API)
* Ditto for editing shows
* Check for applying a new season, works, including overriding the subtype