### PR TITLE
Allow Uni MTA to accept emails from eduroam users.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -1406,8 +1406,13 @@ class MyRadio_User extends ServiceAPI implements APICaller
             if (empty($email)) {
                 continue;
             } else {
-                $data[] = [$user->getLocalAlias(), $email];
-            }
+		$local = $user->getLocalAlias();
+                $data[] = [$local, $email];
+            	$eduroam = $user->getEduroam();
+		if (!empty($eduroam) && ($eduroam !== $email)) {
+                	$data[] = [$eduroam, $email];
+		}
+	    }
         }
 
         return $data;

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -1406,13 +1406,13 @@ class MyRadio_User extends ServiceAPI implements APICaller
             if (empty($email)) {
                 continue;
             } else {
-		$local = $user->getLocalAlias();
+                $local = $user->getLocalAlias();
                 $data[] = [$local, $email];
-            	$eduroam = $user->getEduroam();
-		if (!empty($eduroam) && ($eduroam !== $email)) {
-                	$data[] = [$eduroam, $email];
-		}
-	    }
+                $eduroam = $user->getEduroam();
+                if (!empty($eduroam) && ($eduroam !== $email)) {
+                    $data[] = [$eduroam, $email];
+                }
+            }
         }
 
         return $data;


### PR DESCRIPTION
Make sure that if the user sends email via their eduroam email, that email the server (via myradio/alias-go) will accept that user as valid.