### PR TITLE
Add WebStudio API User Session and Tracklisting

### DIFF
--- a/schema/data-auth.json
+++ b/schema/data-auth.json
@@ -78,7 +78,7 @@
     ["Stop Broadcast","AUTH_STOPBROADCAST", true],
     ["Add Quotes","AUTH_ADD_QUOTES", true],
     ["Upload Music - Manual","AUTH_UPLOADMUSICMANUAL", true]
-    ["User can tracklist own/current show","AUTH_TRACKLIST_OWN", true],
-    ["User can tracklist for any show/timeslot","AUTH_TRACKLIST_ALL", true]
+    ["Tracklist own/current show","AUTH_TRACKLIST_OWN", true],
+    ["Tracklist for any show/timeslot","AUTH_TRACKLIST_ALL", true]
 
 ]

--- a/schema/data-auth.json
+++ b/schema/data-auth.json
@@ -78,4 +78,7 @@
     ["Stop Broadcast","AUTH_STOPBROADCAST", true],
     ["Add Quotes","AUTH_ADD_QUOTES", true],
     ["Upload Music - Manual","AUTH_UPLOADMUSICMANUAL", true]
+    ["User can tracklist own/current show","AUTH_TRACKLIST_OWN", true],
+    ["User can tracklist for any show/timeslot","AUTH_TRACKLIST_ALL", true]
+
 ]

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -258,8 +258,9 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             $timeslot = self::getInstance($_SESSION['timeslotid']);
 
             $result = [
-                "time" => $timeslot->getStartTime(),
-                "timeslotid" => $timeslot->getId()
+                "starttime" => $timeslot->getStartTime(),
+                "timeslotid" => $timeslot->getId(),
+                "title" => $timeslot->getMeta("title")
             ];
             return $result;
         }

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -249,6 +249,15 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
     }
 
     /**
+    * Returns the currently selected timeslot (from the navbar).
+    *
+    * @return int|null If null, no timeslot is selected/user is logged out.
+    */
+    public static function getUserSelectedTimeslot() {
+        return isset($_SESSION['timeslotid']) ? $_SESSION['timeslotid'] : null;
+    }
+
+    /**
      * Sets a metadata key to the specified value.
      *
      * If any value is the same as an existing one, no action will be taken.

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -261,7 +261,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                 "time" => $timeslot->getStartTime(),
                 "timeslotid" => $timeslot->getId()
             ];
-            return result;
+            return $result;
         }
         return null;
     }

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -257,12 +257,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
         if (isset($_SESSION['timeslotid'])) {
             $timeslot = self::getInstance($_SESSION['timeslotid']);
 
-            $result = [
-                "starttime" => $timeslot->getStartTime(),
-                "timeslotid" => $timeslot->getId(),
-                "title" => $timeslot->getMeta("title")
-            ];
-            return $result;
+            return $timeslot;
         }
         return null;
     }

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -251,10 +251,19 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
     /**
     * Returns the currently selected timeslot (from the navbar).
     *
-    * @return int|null If null, no timeslot is selected/user is logged out.
+    * @return array  Time, id If null, no timeslot is selected/user is logged out.
     */
     public static function getUserSelectedTimeslot() {
-        return isset($_SESSION['timeslotid']) ? $_SESSION['timeslotid'] : null;
+        if (isset($_SESSION['timeslotid'])) {
+            $timeslot = self::getInstance($_SESSION['timeslotid']);
+
+            $result = [
+                "time" => $timeslot->getStartTime(),
+                "timeslotid" => $timeslot->getId()
+            ];
+            return result;
+        }
+        return null;
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -135,9 +135,9 @@ class MyRadio_TracklistItem extends ServiceAPI
         self::$db->query('BEGIN');
 
         $audiologid = self::$db->fetchOne(
-            'INSERT INTO tracklist.tracklist (source, timeslotid, starttime, state)
+            'INSERT INTO tracklist.tracklist (source, timeslotid, timestart, state)
             VALUES ($1, $2, $3, $4) RETURNING audiologid',
-            [$sourceid, $timeslotid, CoreUtils::getTimestamp($time), $state]
+            [$sourceid, $timeslotid, CoreUtils::getTimestamp($starttime), $state]
         );
 
         if ($audiologid['audiologid'] == null) {

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -137,7 +137,7 @@ class MyRadio_TracklistItem extends ServiceAPI
         $audiologid = self::$db->fetchOne(
             'INSERT INTO tracklist.tracklist (source, timeslotid, starttime, state)
             VALUES ($1, $2, $3, $4) RETURNING audiologid',
-            [$source, $timeslotid, CoreUtis::getTimestamp($time), $state]
+            [$source, $timeslotid, CoreUtils::getTimestamp($time), $state]
         );
 
         if ($audiologid['audiologid'] == null) {

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -91,10 +91,9 @@ class MyRadio_TracklistItem extends ServiceAPI
 
         if (AuthUtils::hasPermission(AUTH_TRACKLIST_ALL)) {
             $tracklist_all = true;
-        }
-        else if (AuthUtils::hasPermission(AUTH_TRACKLIST_OWN))
+        } else if (AuthUtils::hasPermission(AUTH_TRACKLIST_OWN)) {
             $tracklist_all = false;
-        else {
+        } else {
             throw new MyRadioException("The current user does not have permission to create a tracklistitem.", 403);
         }
 
@@ -115,7 +114,7 @@ class MyRadio_TracklistItem extends ServiceAPI
                 throw new MyRadioException("The current user doesn't have permission to set a tracklist on a show other than their own.", 403);
             }
         } else {
-            if ($tracklist_all == false && !in_array(MyRadio_User::getCurrentUser(), $timeslot->getSeason()->getShow()->getCreditObjects())) {
+            if ($tracklist_all == false && !$this->timeslot->getSeason()->getShow()->isCurrentUserAnOwner()) {
                 throw new MyRadioException("Current user doesn't have permission to tracklist to a show they aren't credited on.", 403);
             }
             if ($timeslot->getStartTime() > $starttime || $timeslot->getEndTime() < $starttime) {
@@ -168,16 +167,16 @@ class MyRadio_TracklistItem extends ServiceAPI
             $time = CoreUtils::getTimestamp();
             if (AuthUtils::hasPermission(AUTH_TRACKLIST_ALL)
                 || (AuthUtils::hasPermission(AUTH_TRACKLIST_OWN)
-                    && in_array(MyRadio_User::getCurrentUser(), $this->timeslot->getSeason()->getShow()->getCreditObjects()))
+                    && $this->timeslot->getSeason()->getShow()->isCurrentUserAnOwner())
             ) {
-                    self::$db->query(
-                        'UPDATE tracklist.tracklist SET timestop=$1 WHERE audiologid=$2',
-                        [$time, $this->getID()]
-                    );
-                    $this->endtime = strtotime($time);
-                } else {
-                    throw new MyRadioException("Current user doesn't have permission to set the endtime of a tracklistitem not from their show.", 403);
-                }
+                self::$db->query(
+                    'UPDATE tracklist.tracklist SET timestop=$1 WHERE audiologid=$2',
+                    [$time, $this->getID()]
+                );
+                $this->endtime = strtotime($time);
+            } else {
+                throw new MyRadioException("Current user doesn't have permission to set the endtime of a tracklistitem not from their show.", 403);
+            }
         } else {
             throw new MyRadioException("This timeslotitem does not have a start time. An end time therefore cannot be set.", 400);
         }

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -109,16 +109,24 @@ class MyRadio_TracklistItem extends ServiceAPI
             $timeslot = MyRadio_Timeslot::getInstance($timeslotid);
         }
 
-        if ($tracklist_all == false && !in_array(MyRadio_User::getCurrentUser(), $this->timeslot->getSeason()->getShow()->getCreditObjects())) {
-            throw new MyRadioException("Current user doesn't have permission to tracklist to a show they aren't credited on.", 403);
+        if ($timeslot == null) {
+            // we're on jukebox
+            if ($tracklist_all == false) {
+                throw new MyRadioException("The current user doesn't have permission to set a tracklist on a show other than their own.", 403);
+            }
+        } else {
+            if ($tracklist_all == false && !in_array(MyRadio_User::getCurrentUser(), $timeslot->getSeason()->getShow()->getCreditObjects())) {
+                throw new MyRadioException("Current user doesn't have permission to tracklist to a show they aren't credited on.", 403);
+            }
+            if ($timeslot->getStartTime() > $starttime || $timeslot->getEndTime() < $starttime) {
+                throw new MyRadioException("The starttime provided was outside the window of the requested timeslot.", 400);
+            }
+
         }
+
 
         if ($starttime == null) {
             $starttime = time();
-        }
-
-        if ($timeslot->getStartTime() > $starttime || $timeslot->getEndTime() < $starttime) {
-            throw new MyRadioException("The starttime provided was outside the window of the requested timeslot.", 400);
         }
 
         $track = MyRadio_Track::getInstance($trackid);

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -137,7 +137,7 @@ class MyRadio_TracklistItem extends ServiceAPI
         $audiologid = self::$db->fetchOne(
             'INSERT INTO tracklist.tracklist (source, timeslotid, starttime, state)
             VALUES ($1, $2, $3, $4) RETURNING audiologid',
-            [$source, $timeslotid, CoreUtils::getTimestamp($time), $state]
+            [$sourceid, $timeslotid, CoreUtils::getTimestamp($time), $state]
         );
 
         if ($audiologid['audiologid'] == null) {

--- a/src/Public/js/myradio.stats.fulltracklist.js
+++ b/src/Public/js/myradio.stats.fulltracklist.js
@@ -26,7 +26,7 @@ $(".twig-datatable").dataTable({
     {
       "sTitle": "Start Time"
     },
-    //starttime
+    //endtime
     {
       "sTitle": "End Time"
     },

--- a/src/Public/js/myradio.stats.fulltracklist.js
+++ b/src/Public/js/myradio.stats.fulltracklist.js
@@ -26,6 +26,10 @@ $(".twig-datatable").dataTable({
     {
       "sTitle": "Start Time"
     },
+    //starttime
+    {
+      "sTitle": "End Time"
+    },
     //label
     {
       sTitle: "Label"


### PR DESCRIPTION
Allows users (with new permissions) to tracklist for shows using WebStudio.

Also allows WebStudio to get the current logged in user/selected timeslot data.