### PR TITLE
Add WebStudio action and associated permissions

### DIFF
--- a/schema/data-actions.json
+++ b/schema/data-actions.json
@@ -68,6 +68,7 @@
     ["MyRadio", "listPermissions"],
     ["MyRadio", "permissionUsage"],
     ["MyRadio", "errorReport"],
+    ["MyRadio", "webstudio"],
     ["NIPSWeb", "default"],
     ["NIPSWeb", "create_token"],
     ["NIPSWeb", "secure_play"],

--- a/schema/data-actionsauth.json
+++ b/schema/data-actionsauth.json
@@ -69,6 +69,7 @@
     ["MyRadio", "pwReset", "AUTH_NOLOGIN"],
     ["MyRadio", "StaticProxy", null],
     ["MyRadio", "timeslot", null],
+    ["MyRadio", "webstudio", "AUTH_ACCESS_WEBSTUDIO"],
     ["NIPSWeb", "confirm_aux_upload", "AUTH_USENIPSWEB"],
     ["NIPSWeb", "confirm_central_upload", "AUTH_USENIPSWEB"],
     ["NIPSWeb", "create_token", "AUTH_USENIPSWEB"],

--- a/schema/data-auth.json
+++ b/schema/data-auth.json
@@ -80,5 +80,5 @@
     ["Upload Music - Manual","AUTH_UPLOADMUSICMANUAL", true]
     ["Tracklist own/current show","AUTH_TRACKLIST_OWN", true],
     ["Tracklist for any show/timeslot","AUTH_TRACKLIST_ALL", true]
-
+    ["Access WebStudio", "AUTH_ACCESS_WEBSTUDIO", true]
 ]

--- a/src/Controllers/MyRadio/webstudio.php
+++ b/src/Controllers/MyRadio/webstudio.php
@@ -5,7 +5,7 @@ use \MyRadio\MyRadio\CoreUtils;
 
 CoreUtils::requireTimeslot();
 
-$location = Config::$website_url . 'webstudio?timeslot_id=' . $_SESSION['timeslotid'];
+$location = Config::$website_url . 'webstudio';
 
 header("HTTP/1.1 302 Found");
 header("Location: $location");

--- a/src/Controllers/MyRadio/webstudio.php
+++ b/src/Controllers/MyRadio/webstudio.php
@@ -1,0 +1,11 @@
+<?php
+
+use \MyRadio\Config;
+use \MyRadio\MyRadio\CoreUtils;
+
+CoreUtils::requireTimeslot();
+
+$location = Config::$website_url . 'webstudio?timeslot_id=' . $_SESSION['timeslotid'];
+
+header("HTTP/1.1 302 Found");
+header("Location: $location");

--- a/src/Menus/menu.json
+++ b/src/Menus/menu.json
@@ -117,6 +117,11 @@
                                         "title": "Studio Information Service",
                                         "url": "module=SIS",
                                         "description": "Access the Studio Information Service."
+                                    },
+                                    {
+                                        "title": "WebStudio",
+                                        "url": "module=MyRadio,action=webstudio",
+                                        "description": "Access WebStudio"
                                     }
                                 ]
                         },


### PR DESCRIPTION
This PR adds an action to direct users to WebStudio.

I've already created an associated "WebStudio Trained" presenterstatus on prod, verified correct operation on Staging.