### PR TITLE
Disable sessions for CLI controller

### DIFF
--- a/src/Controllers/root_cli.php
+++ b/src/Controllers/root_cli.php
@@ -2,4 +2,7 @@
 /**
  * Sets up the environment for MyRadio non-web Controllers.
  */
+
+define("DISABLE_SESSION", true);
+
 require_once __DIR__.'/root.php';


### PR DESCRIPTION
Many of the "sso_session" duplicate errors we've been getting have a common denominator - they're called by root_cli.php. Thing is, CLI actions shouldn't need sessions, as they run as Mr Website... right?