### PR TITLE
email_pipe: use the proper spam status header

### DIFF
--- a/src/Controllers/email_pipe.php
+++ b/src/Controllers/email_pipe.php
@@ -34,8 +34,8 @@ while (!feof($fd)) {
 
 preg_match_all('/(^|\s)From:(.*)/i', $email, $sender);
 preg_match_all('/(^|\s)(To|CC):(.*)/i', $email, $recipients);
-preg_match('/(^|\s)X\-Spam\-Status:(.*)/i', $email, $spam);
-if (!empty($spam) && strtolower(trim($spam[2])) == 'yes') {
+preg_match('/(^|\s)X\-Spam_action:(.*)/i', $email, $spam);
+if (!empty($spam) && strtolower(trim($spam[2])) == 'reject') {
     //Don't archive spam.
     exit(0);
 }


### PR DESCRIPTION
If a message is spam, Exim doesn't set the `X-Spam-Status: yes` header, but rather the `X-Spam_action: reject` header. Update the email_pipe controller to use the correct one.