### PR TITLE
Reduce podcast bitrate to 128kbps

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -859,7 +859,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
     {
         $tmpfile = $this->getArchiveFile();
         $dbfile = $this->getWebFile();
-        shell_exec("nice -n 15 ffmpeg -i '{$tmpfile}' -ab 192k -f mp3 -map 0:a '{$dbfile}'");
+        shell_exec("nice -n 15 ffmpeg -i '{$tmpfile}' -ab 128k -f mp3 -map 0:a '{$dbfile}'");
 
         self::$db->query(
             'UPDATE uryplayer.podcast SET file=$1 WHERE podcast_id=$2',


### PR DESCRIPTION
That's what most of the big players use (tested Serial and Relay FM), and frankly 192k is overkill for an hour of speech anyway