### PR TITLE
Add auth to SIS messages API endpoint

### DIFF
--- a/schema/data-auth.json
+++ b/schema/data-auth.json
@@ -80,5 +80,6 @@
     ["Upload Music - Manual","AUTH_UPLOADMUSICMANUAL", true],
     ["Tracklist own/current show","AUTH_TRACKLIST_OWN", true],
     ["Tracklist for any show/timeslot","AUTH_TRACKLIST_ALL", true],
-    ["Access WebStudio", "AUTH_ACCESS_WEBSTUDIO", true]
+    ["Access WebStudio", "AUTH_ACCESS_WEBSTUDIO", true],
+    ["View Messages for Any Show", "AUTH_ANY_SHOW_MESSAGES", true]
 ]

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -7,6 +7,7 @@
 namespace MyRadio\ServiceAPI;
 
 use MyRadio\Config;
+use MyRadio\MyRadio\AuthUtils;
 use MyRadio\MyRadioException;
 use MyRadio\MyRadio\CoreUtils;
 use MyRadio\MyRadio\URLUtils;
@@ -1064,6 +1065,9 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
 
     public function getMessages($offset = 0)
     {
+        if (!($this->getSeason()->getShow()->isCurrentUserAnOwner())) {
+            AuthUtils::requirePermission(AUTH_ANY_SHOW_MESSAGES);
+        }
         $result = self::$db->fetchAll(
             'SELECT c.commid AS id,
             commtypeid AS type,


### PR DESCRIPTION
This needs to be followed up with a DB change to add in the new permission and give (all? most?) users access to MyRadio_Timeslot::getMessages - it'll take care of authorization