### PR TITLE
Revert "Add include_pending to allpodcasts API, so website can ignore them."

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -331,8 +331,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 [
                     'label' => 'Existing Cover Photo',
                     'explanation' => 'To use an existing cover photo of another podcast, '
-                        . 'copy the Existing Cover Photo file of another '
-                        . 'podcast with that photo into here. For new images, keep blank.',
+                                     . 'copy the Existing Cover Photo file of another '
+                                     . 'podcast with that photo into here. For new images, keep blank.',
                     'required' => false,
                 ]
             )
@@ -844,7 +844,6 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             WHERE podcast_id=$2',
             [CoreUtils::getTimestamp($time), $this->getID()]
         );
-        $this->updateCacheObject();
 
         return $this;
     }
@@ -876,31 +875,13 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
      *
      * @param int $num_results The number of results to return per page. 0 for all podcasts.
      * @param int $page The page required.
-     * @param bool $include_suspended Whether to include suspended podcasts in the result
-     * @param bool $include_pending Whether to include pending (future publish/processing) podcasts in the result
+     * @param bool $includeSuspended Whether to include suspended podcasts in the result
      *
      * @return Array[MyRadio_Podcast]
      */
-    public static function getAllPodcasts(
-        $num_results = 0,
-        $page = 1,
-        $include_suspended = false,
-        $include_pending = false
-    ) {
-        $where = '';
-        if (!$include_suspended || !$include_pending) {
-            $where = 'WHERE ';
-            if (!$include_suspended) {
-                $where .= 'suspended = false';
-            }
-            if (!$include_suspended && !$include_pending) {
-                $where .= ' AND ';
-            }
-            if (!$include_pending) {
-                $where .= 'submitted IS NOT NULL';
-            }
-        }
-
+    public static function getAllPodcasts($num_results = 0, $page = 1, $includeSuspended = true)
+    {
+        $where = !$includeSuspended ? 'WHERE suspended = false ': '';
         $filterLimit = $num_results == 0 ? 'ALL' : $num_results;
         $filterOffset = $num_results * $page;
         $query = "SELECT podcast_id FROM uryplayer.podcast $where";

--- a/src/Controllers/Podcast/allPodcast.php
+++ b/src/Controllers/Podcast/allPodcast.php
@@ -12,5 +12,5 @@ CoreUtils::getTemplateObject()->setTemplate('table.twig')
     ->addVariable('subtitle', 'All Podcasts')
     ->addVariable(
         'tabledata',
-        CoreUtils::setToDataSource(MyRadio_Podcast::getAllPodcasts($include_suspended = true, $include_pending = true))
+        CoreUtils::setToDataSource(MyRadio_Podcast::getAllPodcasts())
     )->render();


### PR DESCRIPTION
Reverted this, as it broke the prod site.

```
/tank/jenkins/workspace/2016-site/go/src/github.com/UniversityRadioYork/2016-site/controllers/index.go:42: /podcast/allpodcasts Not ok: HTTP 500
{"status":"FAIL","payload":"Query failure: SELECT podcast_id FROM uryplayer.podcast WHERE suspended = false AND submitted IS NOT NULLORDER BY submitted DESC OFFSET 0 LIMIT 10;<br>Params: array (\n)<br>ERROR:  syntax error at or near \"NULLORDER\"\nLINE 1: ...cast WHERE suspended = false AND submitted IS NOT NULLORDER ...\n                                                             ^\n","time":"0.028428"}
[negroni] 2020-05-18T16:31:47+01:00 | 0 |        245.64841ms | localhost:5612 | GET /
```