### PR TITLE
Fix SSO 500 Race Condition

### DIFF
--- a/src/Classes/MyRadio/MyRadioSession.php
+++ b/src/Classes/MyRadio/MyRadioSession.php
@@ -70,7 +70,7 @@ class MyRadioSession implements \SessionHandlerInterface
         );
         if (empty($result)) {
             $this->db->query(
-                'INSERT INTO sso_session (id, data, timestamp)
+                'INSERT INTO sso_session (id, data, timestamp) ON CONFLICT DO NOTHING
                 VALUES ($1, \'\', NOW())',
                 [$id]
             );


### PR DESCRIPTION
Seems to be triggered a fair bit by timelord spamming the API on load, one request creates a session just before another is half-way through doing the same, leading to an insertion conflict.

Could we actually get rid of the SELECT and just return the values from the INSERT?