### PR TITLE
Use credits for the timeslot, not whole show.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -128,7 +128,7 @@ class MyRadio_TracklistItem extends ServiceAPI
                 );
             }
         } else {
-            if ($tracklist_all == false && !$timeslot->getSeason()->getShow()->isCurrentUserAnOwner()) {
+            if ($tracklist_all == false && !$timeslot->isCurrentUserAnOwner()) {
                 throw new MyRadioException(
                     "Current user doesn't have permission to tracklist to a show they aren't credited on.",
                     403


### PR DESCRIPTION
Not tested yet, but should fix single timeslot credits from not being able to tracklist.