### PR TITLE
Add permission to let someone train anyone in anything

### DIFF
--- a/schema/data-auth.json
+++ b/schema/data-auth.json
@@ -81,5 +81,6 @@
     ["Tracklist own/current show","AUTH_TRACKLIST_OWN", true],
     ["Tracklist for any show/timeslot","AUTH_TRACKLIST_ALL", true],
     ["Access WebStudio", "AUTH_ACCESS_WEBSTUDIO", true],
-    ["View Messages for Any Show", "AUTH_ANY_SHOW_MESSAGES", true]
+    ["View Messages for Any Show", "AUTH_ANY_SHOW_MESSAGES", true],
+    ["Give Anyone Any Training Status", "AUTH_AWARDANYTRAINING", true]
 ]

--- a/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
@@ -206,6 +206,11 @@ class MyRadio_TrainingStatus extends ServiceAPI
             $user = MyRadio_User::getInstance();
         }
 
+        if ($user->hasAuth(AUTH_AWARDANYTRAINING)) {
+            // I am become trainer, doer of trainings
+            return true;
+        }
+
         return $this->getAwarder()->isAwardedTo($user);
     }
 


### PR DESCRIPTION
As part of the Great 2020 Training Reshuffle, we're adding the first training status that has multiple prerequisites. Now, I'm a lazy bastard who can't be bothered to write the code for that, so instead I'll just make that perm have no prerequisites, and instead give whoever can give it the ability to give anything ;)

This will need to be followed up with a SQL change:

```sql
INSERT INTO public.l_action (descr, phpconstant) VALUES ('Give Anyone Any Training Status', 'AUTH_AWARDANYTRAINING');
```