### PR TITLE
Make training depends and can_award arrays

### DIFF
--- a/schema/data-auth.json
+++ b/schema/data-auth.json
@@ -81,5 +81,6 @@
     ["Tracklist own/current show","AUTH_TRACKLIST_OWN", true],
     ["Tracklist for any show/timeslot","AUTH_TRACKLIST_ALL", true],
     ["Access WebStudio", "AUTH_ACCESS_WEBSTUDIO", true],
-    ["View Messages for Any Show", "AUTH_ANY_SHOW_MESSAGES", true]
+    ["View Messages for Any Show", "AUTH_ANY_SHOW_MESSAGES", true],
+    ["Give Anyone Any Training Status", "AUTH_AWARDANYTRAINING", true]
 ]

--- a/schema/patches/4.sql
+++ b/schema/patches/4.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE public.l_presenterstatus
+    ALTER COLUMN can_award
+        TYPE INTEGER[]
+        USING ARRAY[can_award],
+    ALTER COLUMN depends
+        TYPE INTEGER[]
+        USING ARRAY[depends];
+
+COMMIT;

--- a/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
@@ -206,6 +206,11 @@ class MyRadio_TrainingStatus extends ServiceAPI
             $user = MyRadio_User::getInstance();
         }
 
+        if ($user->hasAuth(AUTH_AWARDANYTRAINING)) {
+            // I am become trainer, doer of trainings
+            return true;
+        }
+
         return $this->getAwarder()->isAwardedTo($user);
     }
 


### PR DESCRIPTION
So my previous PR wasn't enough...

This PR switched training status dependencies to arrays of typeids instead of typeids, and makes the dependency checks use AND-logic - i.e. the depends and can_award columns will now be a list of training statuses you must have.

Will test on dev in a sec.