### PR TITLE
Add MyRadio_User::toDataSource "all_officerships" mixin

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -663,8 +663,10 @@ class MyRadio_User extends ServiceAPI implements APICaller
 
     /**
      * Get all the User's past, present and future officerships.
+     * @param bool $includeMemberships if true, non-officer team memberships will be included
+     * @return array
      */
-    public function getOfficerships()
+    public function getOfficerships($includeMemberships=false)
     {
         if (!$this->officerships) {
             // Get the User's officerships
@@ -673,9 +675,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 FROM member_officer
                 INNER JOIN officer
                 USING (officerid)
-                WHERE memberid = $1
-                AND type!=\'m\'
-                ORDER BY from_date,till_date;',
+                WHERE memberid = $1' . (!$includeMemberships) ? ' AND type!=\'m\'' : ''
+                .' ORDER BY from_date,till_date;',
                 [$this->getID()]
             );
 
@@ -1854,7 +1855,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         } else {
             $welcome_from = null;
         }
-        
+
         //Send the emails
         MyRadioEmail::sendEmailToUser(
             self::getInstance($memberid),
@@ -2174,6 +2175,9 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $mixin_funcs = [
             'officerships' => function (&$data) {
                 $data['officerships'] = $this->getOfficerships();
+            },
+            'all_officerships' => function (&$data) {
+                $data['officerships'] = $this->getOfficerships(true);
             },
             'training' => function (&$data) {
                 $data['training'] = CoreUtils::dataSourceParser($this->getAllTraining());

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -675,7 +675,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 FROM member_officer
                 INNER JOIN officer
                 USING (officerid)
-                WHERE memberid = $1' . (!$includeMemberships) ? ' AND type!=\'m\'' : ''
+                WHERE memberid = $1'
+                . (!$includeMemberships ? ' AND type!=\'m\'' : '')
                 .' ORDER BY from_date,till_date;',
                 [$this->getID()]
             );


### PR DESCRIPTION
The current User API only includes non-membership officerships (so e.g. computing officerships are excluded). Add a way to get at those without doing cursed things.