### PR TITLE
Revert "Add MyRadio_User::toDataSource "all_officerships" mixin"

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -663,10 +663,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
 
     /**
      * Get all the User's past, present and future officerships.
-     * @param bool $includeMemberships if true, non-officer team memberships will be included
-     * @return array
      */
-    public function getOfficerships($includeMemberships=false)
+    public function getOfficerships()
     {
         if (!$this->officerships) {
             // Get the User's officerships
@@ -675,9 +673,9 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 FROM member_officer
                 INNER JOIN officer
                 USING (officerid)
-                WHERE memberid = $1'
-                . (!$includeMemberships ? ' AND type!=\'m\'' : '')
-                .' ORDER BY from_date,till_date;',
+                WHERE memberid = $1
+                AND type!=\'m\'
+                ORDER BY from_date,till_date;',
                 [$this->getID()]
             );
 
@@ -1856,7 +1854,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         } else {
             $welcome_from = null;
         }
-
+        
         //Send the emails
         MyRadioEmail::sendEmailToUser(
             self::getInstance($memberid),
@@ -2176,9 +2174,6 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $mixin_funcs = [
             'officerships' => function (&$data) {
                 $data['officerships'] = $this->getOfficerships();
-            },
-            'all_officerships' => function (&$data) {
-                $data['officerships'] = $this->getOfficerships(true);
             },
             'training' => function (&$data) {
                 $data['training'] = CoreUtils::dataSourceParser($this->getAllTraining());


### PR DESCRIPTION
Reverts UniversityRadioYork/MyRadio#913.

It appears to pollute the cache - after sending an `all_officerships` request, it'll be returned even if an `officerships` request is sent later.