### PR TITLE
Add MyRadio_User::toDataSource "all_officerships" mixin, take two

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -663,8 +663,10 @@ class MyRadio_User extends ServiceAPI implements APICaller
 
     /**
      * Get all the User's past, present and future officerships.
+     * @param bool $includeMemberships if true, non-officer team memberships will be included
+     * @return array
      */
-    public function getOfficerships()
+    public function getOfficerships($includeMemberships=false)
     {
         if (!$this->officerships) {
             // Get the User's officerships
@@ -673,9 +675,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 FROM member_officer
                 INNER JOIN officer
                 USING (officerid)
-                WHERE memberid = $1
-                AND type!=\'m\'
-                ORDER BY from_date,till_date;',
+                WHERE memberid = $1' . (!$includeMemberships) ? ' AND type!=\'m\'' : ''
+                .' ORDER BY from_date,till_date;',
                 [$this->getID()]
             );
 
@@ -1854,7 +1855,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         } else {
             $welcome_from = null;
         }
-        
+
         //Send the emails
         MyRadioEmail::sendEmailToUser(
             self::getInstance($memberid),
@@ -2174,6 +2175,9 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $mixin_funcs = [
             'officerships' => function (&$data) {
                 $data['officerships'] = $this->getOfficerships();
+            },
+            'all_officerships' => function (&$data) {
+                $data['officerships'] = $this->getOfficerships(true);
             },
             'training' => function (&$data) {
                 $data['training'] = CoreUtils::dataSourceParser($this->getAllTraining());

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -675,7 +675,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 FROM member_officer
                 INNER JOIN officer
                 USING (officerid)
-                WHERE memberid = $1' . (!$includeMemberships) ? ' AND type!=\'m\'' : ''
+                WHERE memberid = $1'
+                . (!$includeMemberships ? ' AND type!=\'m\'' : '')
                 .' ORDER BY from_date,till_date;',
                 [$this->getID()]
             );

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -668,9 +668,9 @@ class MyRadio_User extends ServiceAPI implements APICaller
      */
     public function getOfficerships($includeMemberships=false)
     {
-        if (!$this->officerships) {
-            // Get the User's officerships
-            $this->officerships = self::$db->fetchAll(
+        // We don't want it to be cached with includeMemberships
+        if (empty($this->officerships) || $includeMemberships) {
+            $result = self::$db->fetchAll(
                 'SELECT officerid,officer_name,teamid,from_date,till_date
                 FROM member_officer
                 INNER JOIN officer
@@ -680,11 +680,15 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 .' ORDER BY from_date,till_date;',
                 [$this->getID()]
             );
-
-            $this->updateCacheObject();
+            if (!$includeMemberships) {
+                $this->officerships = $result;
+                $this->updateCacheObject();
+            }
+        } else {
+            $result = $this->officerships;
         }
 
-        return $this->officerships;
+        return $result;
     }
 
     /**

--- a/src/Classes/ServiceAPI/ServiceAPI.php
+++ b/src/Classes/ServiceAPI/ServiceAPI.php
@@ -6,6 +6,7 @@ namespace MyRadio\ServiceAPI;
 
 use MyRadio\Config;
 use MyRadio\Database;
+use MyRadio\Iface\CacheProvider;
 use MyRadio\MyRadioException;
 
 /**
@@ -26,7 +27,7 @@ abstract class ServiceAPI
     /**
      * All ServiceAPI subclasses will contain a reference to the CacheProvider Singleton.
      *
-     * @var \CacheProvider
+     * @var CacheProvider
      */
     protected static $cache = null;
 


### PR DESCRIPTION
The current User API only includes non-membership officerships (so e.g. computing officerships are excluded). Add a way to get at those without doing cursed things.

This time with working caching (or lack thereof).