### PR TITLE
Refactor MyRadio_User::getOfficerships

### DIFF
--- a/schema/api.graphql
+++ b/schema/api.graphql
@@ -108,7 +108,7 @@ type User implements Node & MyRadioObject {
 
     # Public information
     shows(current_term_only: Boolean): [Show!] @auth(constants: [])
-    officerships: [MemberOfficership!] @auth(constants: [])
+    officerships(includeMemberships: Boolean): [UserOfficership!] @auth(constants: [])
 
     timeline: [UserTimelineEntry!] @auth(constants: [])
 
@@ -191,10 +191,11 @@ type Officer implements Node & MyRadioObject {
     history: [Officership]
 }
 
-type MemberOfficership {
-    officerid: Int!
-    officer_name: String!
-    teamid: Int!
+type UserOfficership implements Node & MyRadioObject {
+    id: ID!
+    itemId: Int! @bind(method: "getID")
+    user: User!
+    officer: Officer!
     from_date: Date!
     till_date: Date
 }
@@ -340,6 +341,10 @@ type Query {
     nineDaySchedule(weekno: Int!, year: Int): Timeslot @bind(class: "\\MyRadio\\ServiceAPI\\MyRadio_Timeslot", method: "get9DaySchedule")
 
     user(itemid: Int!): User @bind(class: "\\MyRadio\\ServiceAPI\\MyRadio_User", method: "getInstance")
+
+    officer(itemid: Int!): User @bind(class: "\\MyRadio\\ServiceAPI\\MyRadio_Officer", method: "getInstance")
+
+    team(itemid: Int!): User @bind(class: "\\MyRadio\\ServiceAPI\\MyRadio_Team", method: "getInstance")
 
     allTrainingStatuses: [TrainingStatus!] @bind(class: "\\MyRadio\\ServiceAPI\\MyRadio_TrainingStatus", method: "getAll")
 

--- a/schema/api.graphql
+++ b/schema/api.graphql
@@ -196,8 +196,8 @@ type UserOfficership implements Node & MyRadioObject {
     itemId: Int! @bind(method: "getID")
     user: User!
     officer: Officer!
-    from_date: Date!
-    till_date: Date
+    fromDate: Date!
+    tillDate: Date
 }
 
 type TrainingStatus implements Node & MyRadioObject {

--- a/schema/api.graphql
+++ b/schema/api.graphql
@@ -194,8 +194,8 @@ type Officer implements Node & MyRadioObject {
 type UserOfficership implements Node & MyRadioObject {
     id: ID!
     itemId: Int! @bind(method: "getID")
-    user: User!
-    officer: Officer!
+    user: User! @auth(constants: [])
+    officer: Officer! @auth(constants: [])
     fromDate: Date!
     tillDate: Date
 }

--- a/src/Classes/ServiceAPI/MyRadio_Officer.php
+++ b/src/Classes/ServiceAPI/MyRadio_Officer.php
@@ -530,7 +530,7 @@ class MyRadio_Officer extends ServiceAPI
         }
         $officerships = $member->getOfficerships();
         foreach ($officerships as $officership) {
-            if ($officership['officerid'] === $this->getID() && !empty($officership['till_date'])) {
+            if ($officership->getOfficer()->getID() === $this->getID() && !empty($officership->getTillDate())) {
                 return;
             }
         }

--- a/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
@@ -75,7 +75,7 @@ class MyRadio_UserOfficership extends ServiceAPI
         if (empty($data)) {
             throw new MyRadioException("Couldn't track down MyRadio_UserOfficership#$itemid", 404);
         }
-        return new self($itemid);
+        return new self($data);
     }
 
     public function toDataSource($mixins = [])

--- a/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
@@ -82,7 +82,8 @@ class MyRadio_UserOfficership extends ServiceAPI
     {
         return [
             'id' => $this->id,
-            'member' => $this->getUser()->toDataSource($mixins),
+            // Ensure we don't get infinite recursion
+            'member' => $this->getUser()->toDataSource(array_diff($mixins, ['officerships'])),
             'officer' => $this->getOfficer()->toDataSource($mixins),
             'from_date' => $this->from_date,
             'till_date' => $this->till_date

--- a/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
@@ -83,8 +83,8 @@ class MyRadio_UserOfficership extends ServiceAPI
         return [
             'id' => $this->id,
             // Ensure we don't get infinite recursion
-            'member' => $this->getUser()->toDataSource(array_diff($mixins, ['officerships'])),
-            'officer' => $this->getOfficer()->toDataSource($mixins),
+            'member' => $this->getUser()->toDataSource(),
+            'officer' => $this->getOfficer()->toDataSource(),
             'from_date' => $this->from_date,
             'till_date' => $this->till_date
         ];

--- a/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
@@ -4,6 +4,7 @@
 namespace MyRadio\ServiceAPI;
 
 
+use MyRadio\MyRadio\CoreUtils;
 use MyRadio\MyRadioException;
 
 class MyRadio_UserOfficership extends ServiceAPI
@@ -85,8 +86,10 @@ class MyRadio_UserOfficership extends ServiceAPI
             // Ensure we don't get infinite recursion
             'member' => $this->getUser()->toDataSource(),
             'officer' => $this->getOfficer()->toDataSource(),
-            'from_date' => $this->from_date,
-            'till_date' => $this->till_date
+            'from_date' => strftime("%Y-%m-%d", $this->from_date),
+            'till_date' => $this->till_date === null ? null : strftime("%Y-%m-%d", $this->till_date),
+            // Compatibility with old MyRadio_User::getOfficerships
+            'officer_name' => $this->getOfficer()->getName(),
         ];
     }
 

--- a/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserOfficership.php
@@ -1,0 +1,93 @@
+<?php
+
+
+namespace MyRadio\ServiceAPI;
+
+
+use MyRadio\MyRadioException;
+
+class MyRadio_UserOfficership extends ServiceAPI
+{
+    private $id;
+    private $memberid;
+    private $officerid;
+    private $from_date;
+    private $till_date;
+
+    public function __construct($data)
+    {
+        parent::__construct();
+        $this->id = $data['member_officerid'];
+        $this->memberid = $data['memberid'];
+        $this->officerid = $data['officerid'];
+        $this->from_date = strtotime($data['from_date']);
+        $this->till_date = empty($data['till_date']) ? null : strtotime($data['till_date']);
+    }
+
+    /**
+     * @return int
+     */
+    public function getID() {
+        return $this->id;
+    }
+
+    /**
+     * @return MyRadio_User
+     */
+    public function getUser()
+    {
+        return MyRadio_User::getInstance($this->memberid);
+    }
+
+    /**
+     * @return MyRadio_Officer
+     */
+    public function getOfficer()
+    {
+        return MyRadio_Officer::getInstance($this->officerid);
+    }
+
+    /**
+     * @return int
+     */
+    public function getFromDate()
+    {
+        return $this->from_date;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTillDate()
+    {
+        return $this->till_date;
+    }
+
+    protected static function factory($itemid)
+    {
+        $data = self::$db->fetchOne(
+            'SELECT member_officerid, memberid, officerid, from_date, till_date
+            FROM public.member_officer
+            WHERE member_officerid = $1',
+            [$itemid]
+        );
+
+        if (empty($data)) {
+            throw new MyRadioException("Couldn't track down MyRadio_UserOfficership#$itemid", 404);
+        }
+        return new self($itemid);
+    }
+
+    public function toDataSource($mixins = [])
+    {
+        return [
+            'id' => $this->id,
+            'member' => $this->getUser()->toDataSource($mixins),
+            'officer' => $this->getOfficer()->toDataSource($mixins),
+            'from_date' => $this->from_date,
+            'till_date' => $this->till_date
+        ];
+    }
+
+
+}


### PR DESCRIPTION
This changes it from returning a hacky array to a new class, MyRadio_UserOfficership, and updates all call sites to match. The primary benefit is a much cleaner GraphQL API - instead of just getting an "officerid", all officership info can be traversed directly from the User object