### PR TITLE
Use is_in_byline to generate presenter string.

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Creditable.php
+++ b/src/Classes/ServiceAPI/MyRadio_Creditable.php
@@ -104,13 +104,13 @@ trait MyRadio_Creditable
         $credit_types = MyRadio_Scheduler::getCreditTypes();
         $credit_types_in_byline = [];
         foreach ($credit_types as $type) {
-            if ($type["is_in_byline"]) {
+            if ($type["is_in_byline"] == "t") {
                 $credit_types_in_byline[] = $type["value"];
             }
         }
         $str = '';
         foreach ($this->getCredits() as $credit) {
-            if (inarray($credit['type'], $credit_types_in_byline)) {
+            if (in_array($credit['type'], $credit_types_in_byline)) {
                 $str .= $credit['User']->getName().', ';
             } else {
                 continue;

--- a/src/Classes/ServiceAPI/MyRadio_Creditable.php
+++ b/src/Classes/ServiceAPI/MyRadio_Creditable.php
@@ -5,6 +5,7 @@
 namespace MyRadio\ServiceAPI;
 
 use MyRadio\ServiceAPI\MyRadio_User;
+use MyRadio\ServiceAPI\MyRadio_Scheduler;
 
 /**
  * The MyRadio_Creditable trait adds credits functionality to an object.
@@ -100,12 +101,19 @@ trait MyRadio_Creditable
      */
     public function getPresenterString()
     {
+        $credit_types = MyRadio_Scheduler::getCreditTypes();
+        $credit_types_in_byline = [];
+        foreach ($credit_types as $type) {
+            if ($type["is_in_byline"]) {
+                $credit_types_in_byline[] = $type["value"];
+            }
+        }
         $str = '';
         foreach ($this->getCredits() as $credit) {
-            if ($credit['type'] !== 1) {
-                continue;
-            } else {
+            if (inarray($credit['type'], $credit_types_in_byline)) {
                 $str .= $credit['User']->getName().', ';
+            } else {
+                continue;
             }
         }
 

--- a/src/Classes/ServiceAPI/MyRadio_Scheduler.php
+++ b/src/Classes/ServiceAPI/MyRadio_Scheduler.php
@@ -211,7 +211,7 @@ class MyRadio_Scheduler extends ServiceAPI
         self::wakeup();
 
         return self::$db->fetchAll(
-            'SELECT credit_type_id AS value, name AS text
+            'SELECT credit_type_id AS value, name AS text, is_in_byline
             FROM people.credit_type ORDER BY name ASC'
         );
     }


### PR DESCRIPTION
This allows co-presenters (and others, as specified in the credits db table) to appear in the presenters string used by radioplayer etc. Replaces #800.