### PR TITLE
Use SELECT DISTINCT to avoid returning the same search result multiple times

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_MetadataSubject.php
+++ b/src/Classes/ServiceAPI/MyRadio_MetadataSubject.php
@@ -292,7 +292,7 @@ trait MyRadio_MetadataSubject
         $query = urldecode($query);
 
         $results = self::$db->fetchColumn(
-            'SELECT '.$id_field
+            'SELECT DISTINCT '.$id_field
             .' FROM '.$table
             .' WHERE metadata_value ILIKE \'%\' || $1 || \'%\''
             .' AND metadata_key_id IN '.$meta_keys /* safe - we control keys via getMetadataKey */


### PR DESCRIPTION
https://ury.org.uk/search/?term=mixer has the same show five? times.