### PR TITLE
Add AUTH_USENIPSWEB check to MyrTimeslot::getShowPlan

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -1037,7 +1037,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
     {
         // Check we can access it, if not, require permission
         if (!($this->isCurrentUserAnOwner())) {
-            AuthUtils::requirePermission(AUTH_USENIPSWEB);
+            AuthUtils::requirePermission(AUTH_VIEWMEMBERSHOWS);
         }
 
         /*

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -1035,6 +1035,11 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
      */
     public function getShowPlan()
     {
+        // Check we can access it, if not, require permission
+        if (!($this->isCurrentUserAnOwner())) {
+            AuthUtils::requirePermission(AUTH_USENIPSWEB);
+        }
+
         /*
          * Find out if there's a NIPSWeb Schema listing for this timeslot.
          * If not, throw back an empty array


### PR DESCRIPTION
To ensure that non-WS-Trained people can still access it.

**Note:** I reused AUTH_USENIPSWEB to avoid creating _yet another_ permission - so, when this is merged, we'll need to change auth for MyRadio_Timeslot::getShowPlan to NULL, and also reduce the number of people with AUTH_USENIPSWEB. In fact, now that I write this, might it be better to just add a new one, or rename AUTH_USENIPSWEB?