### PR TITLE
MyRadio_Timeslot: throw 404 not 400 if it doesn’t exist

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -108,7 +108,7 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
             //Invalid Season
             throw new MyRadioException(
                 'The MyRadio_Timeslot with instance ID #' . $timeslot_id . ' does not exist.',
-                400
+                404
             );
         }
 


### PR DESCRIPTION
Don’t *think* this is a breaking change? Just more semantically correct.