### PR TITLE
Only new tabs for external links

### DIFF
--- a/src/Templates/MyRadio/menu.twig
+++ b/src/Templates/MyRadio/menu.twig
@@ -45,7 +45,15 @@
       {% if item.template is not same as(null) %}
       {% include item.template %}
       {% else %}
-      <li><a href="{{ item.url }}{{ '?' in item.url ? '&' : '?' }}ref={{ item.title | e('url') }}" target="_blank" title="{{ item.description | replace({'"': '&quot;'}) | raw }}">{{ item.title }}</a></li>
+      <li><a 
+        href="{{ item.url }}{{ '?' in item.url ? '&' : '?' }}ref={{ item.title | e('url') }}"  
+        {% if config.base_url not in item.url %}
+          target="_blank" 
+        {% endif %} 
+        title="{{ item.description | replace({'"': '&quot;'}) | raw }}"
+        >
+        {{ item.title }}
+        </a></li>
       {% endif %}
     {% endfor %}
     </ul>


### PR DESCRIPTION
Makes it so only clicking on non MyRadio links will open in new tabs, any internal link will use the same tab