### PR TITLE
Spell description correctly

### DIFF
--- a/src/Menus/menu.json
+++ b/src/Menus/menu.json
@@ -210,7 +210,7 @@
                         {
                             "title": "Minutes",
                             "url": "https://drive.google.com/drive/folders/1txLjiR0LUvaZo9DvuDjN7uGHrPkGGmkX",
-                            "decription": "Want to know what happened in previous station meetings? Check the documents out here."
+                            "description": "Want to know what happened in previous station meetings? Check the documents out here."
                         },
                         {
                             "title": "Officers",


### PR DESCRIPTION
Change "decription" to "description" so the minutes description actually works