### PR TITLE
Add mapping of tracklist sources to sel sources

### DIFF
--- a/schema/base.sql
+++ b/schema/base.sql
@@ -2112,7 +2112,7 @@ CREATE TABLE selsources (
     selaction integer NOT NULL,
     sourceid character(1) NOT NULL
 );
-COMMENT ON TABLE selbaps IS 'Marries selector actions with tracklist sources';
+COMMENT ON TABLE selsources IS 'Marries selector actions with tracklist sources';
 CREATE TABLE source (
     sourceid character(1) NOT NULL,
     source text NOT NULL

--- a/schema/base.sql
+++ b/schema/base.sql
@@ -6616,7 +6616,7 @@ ALTER TABLE ONLY selbaps
 --
 
 ALTER TABLE ONLY selsources
-    ADD CONSTRAINT selsources_sourceid_fkey FOREIGN KEY (sourceid) REFERENCES tracklist.selsources(sourceid);
+    ADD CONSTRAINT selsources_sourceid_fkey FOREIGN KEY (sourceid) REFERENCES tracklist.source(sourceid);
 
 
 --

--- a/schema/base.sql
+++ b/schema/base.sql
@@ -2108,11 +2108,6 @@ CREATE TABLE selbaps (
     bapsloc integer NOT NULL
 );
 COMMENT ON TABLE selbaps IS 'Marries selector actions with BAPS servers';
-CREATE TABLE selsources (
-    selaction integer NOT NULL,
-    sourceid character(1) NOT NULL
-);
-COMMENT ON TABLE selsources IS 'Marries selector actions with tracklist sources';
 CREATE TABLE source (
     sourceid character(1) NOT NULL,
     source text NOT NULL
@@ -6609,22 +6604,6 @@ ALTER TABLE ONLY selbaps
 
 ALTER TABLE ONLY selbaps
     ADD CONSTRAINT selbaps_selaction_fkey FOREIGN KEY (selaction) REFERENCES public.selector_actions(action);
-
-
---
--- Name: selsources_sourceid_fkey; Type: FK CONSTRAINT; Schema: tracklist
---
-
-ALTER TABLE ONLY selsources
-    ADD CONSTRAINT selsources_sourceid_fkey FOREIGN KEY (sourceid) REFERENCES tracklist.source(sourceid);
-
-
---
--- Name: selsources_selaction_fkey; Type: FK CONSTRAINT; Schema: tracklist
---
-
-ALTER TABLE ONLY selsources
-    ADD CONSTRAINT selsources_selaction_fkey FOREIGN KEY (selaction) REFERENCES public.selector_actions(action);
 
 
 --

--- a/schema/base.sql
+++ b/schema/base.sql
@@ -2108,6 +2108,11 @@ CREATE TABLE selbaps (
     bapsloc integer NOT NULL
 );
 COMMENT ON TABLE selbaps IS 'Marries selector actions with BAPS servers';
+CREATE TABLE selsources (
+    selaction integer NOT NULL,
+    sourceid character(1) NOT NULL
+);
+COMMENT ON TABLE selbaps IS 'Marries selector actions with tracklist sources';
 CREATE TABLE source (
     sourceid character(1) NOT NULL,
     source text NOT NULL
@@ -6604,6 +6609,22 @@ ALTER TABLE ONLY selbaps
 
 ALTER TABLE ONLY selbaps
     ADD CONSTRAINT selbaps_selaction_fkey FOREIGN KEY (selaction) REFERENCES public.selector_actions(action);
+
+
+--
+-- Name: selsources_sourceid_fkey; Type: FK CONSTRAINT; Schema: tracklist
+--
+
+ALTER TABLE ONLY selsources
+    ADD CONSTRAINT selsources_sourceid_fkey FOREIGN KEY (sourceid) REFERENCES tracklist.selsources(sourceid);
+
+
+--
+-- Name: selsources_selaction_fkey; Type: FK CONSTRAINT; Schema: tracklist
+--
+
+ALTER TABLE ONLY selsources
+    ADD CONSTRAINT selsources_selaction_fkey FOREIGN KEY (selaction) REFERENCES public.selector_actions(action);
 
 
 --

--- a/schema/patches/9.sql
+++ b/schema/patches/9.sql
@@ -1,0 +1,20 @@
+CREATE TABLE selsources (
+    selaction integer NOT NULL,
+    sourceid character(1) NOT NULL
+);
+COMMENT ON TABLE selsources IS 'Marries selector actions with tracklist sources';
+
+--
+-- Name: selsources_sourceid_fkey; Type: FK CONSTRAINT; Schema: tracklist
+--
+
+ALTER TABLE ONLY selsources
+    ADD CONSTRAINT selsources_sourceid_fkey FOREIGN KEY (sourceid) REFERENCES tracklist.source(sourceid);
+
+
+--
+-- Name: selsources_selaction_fkey; Type: FK CONSTRAINT; Schema: tracklist
+--
+
+ALTER TABLE ONLY selsources
+    ADD CONSTRAINT selsources_selaction_fkey FOREIGN KEY (selaction) REFERENCES public.selector_actions(action);

--- a/src/Classes/ServiceAPI/MyRadio_Selector.php
+++ b/src/Classes/ServiceAPI/MyRadio_Selector.php
@@ -209,13 +209,13 @@ class MyRadio_Selector
     }
 
     /**
-     * Returns what studio was on air at the time given.
+     * Returns which selector action was last performed at the time given.
      *
      * @param int $time
      *
      * @return int
      */
-    public static function getStudioAtTime($time = null)
+    public static function getSelActionAtTime($time = null)
     {
         if ($time === null) {
             $time = time();
@@ -232,8 +232,21 @@ class MyRadio_Selector
         if (!$result) {
             return 0;
         }
+        return $result[0];
+    }
 
-        return $result[0] - 3;
+    /**
+     * Returns what studio was on air at the time given.
+     *
+     * @param int $time
+     *
+     * @return int
+     */
+    public static function getStudioAtTime($time = null)
+    {
+        $result = getSelActionAtTime($time);
+
+        return $result - 3;
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -152,7 +152,7 @@ class MyRadio_TracklistItem extends ServiceAPI
 
         # If we've been left to work out which state we're in (confirmed or off air), let's look this up.
         if ($state == null) {
-            $state = in_array($sourceid, getTracklistSourcesOnAirAtTime($starttime)) ? 'c': 'o';
+            $state = in_array($sourceid, self::getTracklistSourcesOnAirAtTime($starttime)) ? 'c': 'o';
         }
 
         self::$db->query('BEGIN');

--- a/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
+++ b/src/Classes/ServiceAPI/MyRadio_TracklistItem.php
@@ -71,7 +71,6 @@ class MyRadio_TracklistItem extends ServiceAPI
         return new self($result);
     }
 
-
     /**
      * Create a new TracklistItem, returning the new item.
      *
@@ -87,7 +86,7 @@ class MyRadio_TracklistItem extends ServiceAPI
      *
      * @throws MyRadioException
      */
-    public static function create($trackid, $timeslotid = null, $starttime = null, $sourceid = 'a', $state = 'c')
+    public static function create($trackid, $timeslotid = null, $starttime = null, $sourceid = 'a', $state = null)
     {
 
         if (AuthUtils::hasPermission(AUTH_TRACKLIST_ALL)) {
@@ -151,6 +150,10 @@ class MyRadio_TracklistItem extends ServiceAPI
 
         $track = MyRadio_Track::getInstance($trackid);
 
+        # If we've been left to work out which state we're in (confirmed or off air), let's look this up.
+        if ($state == null) {
+            $state = in_array($sourceid, getTracklistSourcesOnAirAtTime($starttime)) ? 'c': 'o';
+        }
 
         self::$db->query('BEGIN');
 
@@ -232,6 +235,25 @@ class MyRadio_TracklistItem extends ServiceAPI
     public function getStartTime()
     {
         return $this->starttime;
+    }
+
+    /**
+     * Get which tracklist sources (tracklist.source) are on air based on the selector status at a given time.
+     *
+     * @param int $time    Epoch time. Optional, defaults to current time.
+     *
+     * @return char[] Tracklist sources
+     */
+    public static function getTracklistSourcesOnAirAtTime($time = null)
+    {
+        $sel_action = MyRadio_Selector::getSelActionAtTime($time);
+
+        $sources = self::$db->fetchColumn(
+            'SELECT sourceid FROM tracklist.selsources WHERE selaction=$1',
+            [$sel_action]
+        );
+
+        return $sources;
     }
 
     /**


### PR DESCRIPTION
This is to allow support via API for BAPS3 to tracklist always, but only show in tracklists if the studio is on air.

Instead of using the server name mapping in BAPS2, this proposes to create 3 tracklist source chars (studio red, blue and OB), configured on each server.

Note, the table will need to be created (if I haven't done it already) in prod db, and all source mapping combos added (including webstudio to sel 5, etc).

Needs testing.