### PR TITLE
Mark podcast as dirty when done converting

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -981,6 +981,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
         if (empty($this->submitted)) {
             $this->setSubmitted(time());
         }
+        
+        $this->updateCacheObject();
     }
 
     /**


### PR DESCRIPTION
This _might_ fix the "need to yeet cache after uploading" issues. I'd quite like to make a nicer "pending state" implementation rather than just assuming `{file, submitted} == null => pending`, but that's outside the scope of this PR.