### PR TITLE
Attempt to fix podcast caching, yet again

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -983,7 +983,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             $this->setSubmitted(time());
         }
 
-        $this->updateCacheObject();
+        $this->updateCacheObject(true);
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -494,7 +494,8 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             [MyRadio_User::getInstance()->getID()]
         )[0];
 
-
+        // DANGER WILL ROBINSON DANGER
+        /** @var self $podcast */
         $podcast = self::getInstance($id);
 
         $podcast->setMeta('title', $title);
@@ -505,6 +506,32 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
             $podcast->setShow($show);
         }
 
+        // Pre-emptively write the current state of this object to the cache.
+        // We need to do this, because the self::getInstance() call above
+        // poisoned the cache with a NULL $podcast->metadata. So anything
+        // that tries to read it from now on will hit the cache and get
+        // an outdated copy. The only remedy is to, effectively, re-poison it
+        // with the correct value. Yes, this is absolutely cursed.
+        //
+        // This is, however, safe: nothing should be able to know the podcast's
+        // ID until the COMMIT statement afterwards. So by the time it
+        // has an ID, it will have a freshly baked, correct value waiting
+        // for it in the cache.
+        //
+        // This is not a unique problem; in theory, every ServiceAPI subclass
+        // is vulnerable.
+        //
+        // This is more likely to happen to podcasts than any other type,
+        // because podcasts are immediately touched by the podcast daemon upon
+        // creation, which will hold on to the cached instance while it
+        // converts the file, which may take _a while_ - and then write
+        // back the copy, poisoning the cache until it expires or gets flushed.
+        // Putting $this->updateCacheObject() (or even a self::$cache->purge())
+        // at the end of this method will not help, because by the time this
+        // function finishes the daemon will have already obtained a reference
+        // to a poisoned copy.
+
+        $podcast->updateCacheObject(true);
         self::$db->query('COMMIT');
 
         //Ship the file off to the archive location to be converted

--- a/src/Classes/ServiceAPI/ServiceAPI.php
+++ b/src/Classes/ServiceAPI/ServiceAPI.php
@@ -155,8 +155,7 @@ abstract class ServiceAPI
     public function __destruct()
     {
         if ($this->change) {
-            $this->change = false;
-            self::$cache->set(self::getCacheKey($this->getID()), $this);
+            $this->write();
         }
     }
 
@@ -176,10 +175,24 @@ abstract class ServiceAPI
      * Sets the cache for this object to be the current object state.
      *
      * This should always be called after a setSomething.
+     * @param bool $forceWrite whether to immediately write to the cache, or wait until the object is destroyed
      */
-    protected function updateCacheObject()
+    protected function updateCacheObject(bool $forceWrite = false)
     {
-        $this->change = true;
+        if ($forceWrite) {
+            $this->write();
+        } else {
+            $this->change = true;
+        }
+    }
+
+    /**
+     * Writes this object to the cache.
+     */
+    private function write(): void
+    {
+        $this->change = false;
+        self::$cache->set(self::getCacheKey($this->getID()), $this);
     }
 
     /**
@@ -193,4 +206,5 @@ abstract class ServiceAPI
         return true;
         unset(self::$singletons[self::getCacheKey($this->getID())]);
     }
+
 }


### PR DESCRIPTION
The following paragraph about summarises the cursedness of this issue:

```php
// Pre-emptively write the current state of this object to the cache.
// We need to do this, because the self::getInstance() call above
// poisoned the cache with a NULL $podcast->metadata. So anything
// that tries to read it from now on will hit the cache and get
// an outdated copy. The only remedy is to, effectively, re-poison it
// with the correct value. Yes, this is absolutely cursed.
//
// This is, however, safe: nothing should be able to know the podcast's
// ID until the COMMIT statement afterwards. So by the time it
// has an ID, it will have a freshly baked, correct value waiting
// for it in the cache.
//
// This is not a unique problem; in theory, every ServiceAPI subclass
// is vulnerable.
//
// This is more likely to happen to podcasts than any other type,
// because podcasts are immediately touched by the podcast daemon upon
// creation, which will hold on to the cached instance while it
// converts the file, which may take _a while_ - and then write
// back the copy, poisoning the cache until it expires or gets flushed.
// Putting $this->updateCacheObject() (or even a self::$cache->purge())
// at the end of this method will not help, because by the time this
// function finishes the daemon will have already obtained a reference
// to a poisoned copy.
```