### PR TITLE
Quick fix for methods that take only one parameter breaking (un-revert #1019)

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -174,11 +174,11 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
     /**
      * Get all the Podcasts that the User is Owner of Creditor of.
      *
-     * @param MyRadio_User $user Default current user.
+     * @param int|string|MyRadio_User $user Default current user.
      *
      * @return MyRadio_Podcast[]
      */
-    public static function getPodcastsAttachedToUser(MyRadio_User $user = null)
+    public static function getPodcastsAttachedToUser($user = null)
     {
         return self::resultSetToObjArray(self::getPodcastIDsAttachedToUser($user));
     }
@@ -186,14 +186,20 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
     /**
      * Get the IDs of all the Podcasts that the User is Owner of Creditor of.
      *
-     * @param MyRadio_User $user Default current user.
+     * @param int|string|MyRadio_User $user Default current user.
      *
      * @return int[]
      */
-    public static function getPodcastIDsAttachedToUser(MyRadio_User $user = null)
+    public static function getPodcastIDsAttachedToUser($user = null)
     {
         if ($user === null) {
             $user = MyRadio_User::getInstance();
+        } elseif (is_int($user)) {
+            $user = MyRadio_User::getInstance($user);
+        } elseif (is_string($user) && is_numeric($user)) {
+            $user = MyRadio_User::getInstance(intval($user));
+        } elseif (!($user instanceof MyRadio_User)) {
+            throw new MyRadioException('Invalid user input');
         }
 
         return self::$db->fetchColumn(

--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -207,8 +207,9 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
                 $status = '201 Created';
             }
 
-            // Don't send the API key to the function
+            // Don't send the API key or mixins to the function (mixins are handled later)
             unset($args['api_key']);
+            unset($args['mixins']);
 
             $data = [
                 'status' => $status,


### PR DESCRIPTION
There's an obscure case in the API code where api_key and mixins could leak into a method's arguments when they really never should. This PR fixes that case, and also un-reverts #1015 (which was blocked due to this).

This doesn't fix the general case though - try calling https://ury.org.uk/api-staging/v2/show/14066/credits?unexpected=gobbledygok - if a method that takes one parameter is called with one parameter, no validation is done to ensure that it's actually called with the expected parameter.

I'm not sure how best to fix that, honestly - the comment on https://github.com/UniversityRadioYork/MyRadio/blob/master/src/PublicAPI/index.php#L59 refers to the case where "the request body is the param", and I'm not quite sure what that means. Perhaps we just accept this as a fact of life, although we may want to catch this error instead of spewing the MyRadio stack (though it's hard to do that without masking another type error from inside that function...).

To test: go to https://ury.org.uk/api-staging/v2/show/14066/credits?api_key=insert_apikey_here.