### PR TITLE
BREAKING CHANGE: createOrActivate return null when user exists

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -1948,7 +1948,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
      *
      * @api POST
      *
-     * @return MyRadio_User
+     * @return MyRadio_User|null
      */
     public static function createOrActivate(
         $fname,
@@ -1967,8 +1967,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         }
 
         if ($user !== null && $user->activateMemberThisYear($paid)) {
-            // @todo send welcome email to already existing users?
-            return $user;
+            return null;
         } else {
             $data = [
                 'fname' => $fname,

--- a/src/Controllers/Profile/bulkAdd.php
+++ b/src/Controllers/Profile/bulkAdd.php
@@ -23,7 +23,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $params['eduroam'],
                 $params['collegeid']
             );
-            $template->addInfo('Added Member with ID '.$user->getID());
+            if ($user === null) {
+                $template->addInfo($params['fname'] . ' ' . $params['sname'] . ' already has an account!');
+            } else {
+                $template->addInfo('Added Member with ID '.$user->getID());
+            }
         } catch (MyRadioException $e) {
             $template->addError('Could not add '.$params['eduroam'].': '.$e->getMessage());
         }

--- a/src/Controllers/Profile/quickAdd.php
+++ b/src/Controllers/Profile/quickAdd.php
@@ -17,7 +17,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $params['phone']
     );
 
-    URLUtils::backWithMessage('New Member has been created with ID '.$user->getID());
+    if ($user === null) {
+        $msg = 'This member already has an account!';
+    } else {
+        $msg = 'New Member has been created with ID '.$user->getID();
+    }
+    URLUtils::backWithMessage($msg);
 } else {
     //Not Submitted
     MyRadio_User::getQuickAddForm()->render();


### PR DESCRIPTION
Every year we have the problem of people getting confused when they sign up and don't get an email, because they already had an account.

This commit changes MyRadio_User::createOrActivateUser() to return null when the user already existed before it was called.

This is a BREAKING CHANGE because, although all MyRadio callsites have been updated, various places use its API and would need updating too (off the top of my head, /getinvolved and the alumni signup form).

This also technically introduces an account enumeration vulnerability, but personally I think the UX benefit is worth the marginal added risk.