### PR TITLE
Set a variable attendee count for demos

### DIFF
--- a/schema/patches/6.sql
+++ b/schema/patches/6.sql
@@ -10,6 +10,7 @@ create table schedule.demo
 			references l_presenterstatus,
 	demo_time timestamp with time zone not null,
 	demo_link text,
+	num_people int,
 	memberid int
 		constraint demo_member_memberid_fk
 			references member

--- a/src/Controllers/Training/createDemo.php
+++ b/src/Controllers/Training/createDemo.php
@@ -15,11 +15,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         MyRadio_Demo::getInstance($demoinfo['id'])->editDemo(
             $demoinfo['demo_datetime'],
             $demoinfo['demo_training_type'],
-            $demoinfo['demo_link']
+            $demoinfo['demo_link'],
+	    $demoinfo['num_people']
         );
     } else {
         // Create a New Demo
-        MyRadio_Demo::registerDemo($demoinfo['demo_datetime'], $demoinfo['demo_training_type'], $demoinfo['demo_link']);
+        MyRadio_Demo::registerDemo($demoinfo['demo_datetime'], $demoinfo['demo_training_type'], $demoinfo['demo_link'], $demoinfo['num_people']);
     }
     URLUtils::backWithMessage('Session Updated!');
 } else {

--- a/src/Controllers/Training/listDemos.php
+++ b/src/Controllers/Training/listDemos.php
@@ -84,7 +84,7 @@ if (isset($_REQUEST['msg'])) {
             $twig->addInfo('You have successfully been added to this session.');
             break;
         case 1: //full
-            $twig->addError('Sorry, but a maximum two people can join a session.');
+            $twig->addError('Sorry, but this session is full.');
             break;
         case 2: //attending already
             $twig->addError('You can only attend one session for that training at a time.');

--- a/src/Templates/Training/createDemo.twig
+++ b/src/Templates/Training/createDemo.twig
@@ -3,7 +3,7 @@
 {{ parent() }}
 {% endblock %}
 {% block stripecontent %}
-<p>All sessions will last one hour, take a maximum of two participants and happen in a free studio. You will be registered as the Trainer for this session.</p>
+<p>All sessions will last one hour and take place in a free studio (if not online). You will be registered as the Trainer for this session.</p>
 {{ parent() }}
 <iframe src="{{ config.schedule_url }}" style="width:100%; height: 1500px"></iframe>
 {% endblock %}


### PR DESCRIPTION
Adds the ability to set an amount of attendees for a training event, making the "max of 2" more variable. Useful for cases when either 1 person is wanted or an arbitrarily large amount of people are wanted. 

Also there are slight changes like making a function return early when it (not doing anything else) throws an error and testing if an edited event has a valid date. 

Warning: I have not tested this so I don't know if it will work.