### PR TITLE
Fix local install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ CONNECT:
 DATABASE:
  - On the intro screen press "Click here to continue"
  - Enter the database details (see Database Credentials) and press Next
- - Press "run task"
+ - Press "run task", wait a few seconds and then press "run task" again.
+ - [This delay and repetition is a workaround for a slight bug in how we build the database]
  
 USER:
  - [Here you can make config changes but the defaults are autofilled]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/ubuntu-19.10"
+  config.vm.box = "bento/ubuntu-20.04"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/schema/base.sql
+++ b/schema/base.sql
@@ -820,7 +820,6 @@ CREATE SEQUENCE types_id_seq
     CACHE 1;
 ALTER SEQUENCE types_id_seq OWNED BY role_visibility.role_visibility_id;
 SET search_path = public, pg_catalog;
-SET default_with_oids = true;
 CREATE TABLE auth (
     memberid integer NOT NULL,
     lookupid integer NOT NULL,
@@ -831,7 +830,6 @@ CREATE TABLE auth (
 COMMENT ON TABLE auth IS 'Grants users temporary permissions on the back end.';
 COMMENT ON COLUMN auth.lookupid IS 'Permission granded to the user';
 COMMENT ON COLUMN auth.endtime IS 'Permission runs out now; NULL = permenant.';
-SET default_with_oids = false;
 CREATE TABLE auth_group (
     id integer NOT NULL,
     name character varying(80) NOT NULL
@@ -843,13 +841,11 @@ CREATE SEQUENCE auth_group_id_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE auth_group_id_seq OWNED BY auth_group.id;
-SET default_with_oids = true;
 CREATE TABLE auth_officer (
     officerid integer NOT NULL,
     lookupid integer NOT NULL
 );
 COMMENT ON TABLE auth_officer IS 'Grants permanent back end permissions to people currently holding officer posts.';
-SET default_with_oids = false;
 CREATE TABLE auth_subnet (
     typeid integer NOT NULL,
     subnet cidr NOT NULL
@@ -898,7 +894,6 @@ CREATE SEQUENCE banner_category_categoryid_seq
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-SET default_with_oids = true;
 CREATE TABLE baps_audio (
     audioid integer NOT NULL,
     trackid integer,
@@ -1105,7 +1100,6 @@ CREATE SEQUENCE baps_user_userid_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE baps_user_userid_seq OWNED BY baps_user.userid;
-SET default_with_oids = false;
 CREATE TABLE chart (
     chartweek integer NOT NULL,
     lastweek text NOT NULL,
@@ -1130,7 +1124,6 @@ CREATE TABLE gammu (
     "Version" numeric
 );
 COMMENT ON TABLE gammu IS 'Do not delete - Gammu will break';
-SET default_with_oids = true;
 CREATE TABLE l_action (
     typeid integer DEFAULT nextval(('"l_action_typeid_seq"'::text)::regclass) NOT NULL,
     descr character varying(255) NOT NULL,
@@ -1167,7 +1160,6 @@ CREATE SEQUENCE l_musicinterest_typeid_seq
     NO MINVALUE
     MAXVALUE 2147483647
     CACHE 1;
-SET default_with_oids = false;
 CREATE TABLE l_newsfeed (
     feedid integer NOT NULL,
     feedname character varying(30) NOT NULL
@@ -1184,7 +1176,6 @@ CREATE SEQUENCE l_newsfeeds_feedid_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE l_newsfeeds_feedid_seq OWNED BY l_newsfeed.feedid;
-SET default_with_oids = true;
 CREATE TABLE l_presenterstatus (
     presenterstatusid integer NOT NULL,
     descr character varying(40) NOT NULL,
@@ -1205,7 +1196,6 @@ CREATE TABLE l_status (
     statusid character(1) NOT NULL,
     descr character varying(255) NOT NULL
 );
-SET default_with_oids = false;
 CREATE TABLE l_subnet (
     subnet cidr NOT NULL,
     iscollege boolean NOT NULL,
@@ -1283,7 +1273,6 @@ CREATE TABLE mail_subscription (
     listid integer NOT NULL
 );
 COMMENT ON TABLE mail_subscription IS 'If a list is subscribable, then all members here are subscribed.  If a list is not, then all members here are opted out.';
-SET default_with_oids = true;
 CREATE TABLE member (
     memberid integer DEFAULT nextval(('"member_memberid_seq"'::text)::regclass) NOT NULL,
     fname character varying(255) NOT NULL,
@@ -1318,7 +1307,6 @@ CREATE SEQUENCE member_memberid_seq
     NO MINVALUE
     MAXVALUE 2147483647
     CACHE 1;
-SET default_with_oids = false;
 CREATE TABLE member_news_feed (
     membernewsfeedid integer NOT NULL,
     newsentryid integer NOT NULL,
@@ -1339,7 +1327,6 @@ CREATE SEQUENCE member_office_member_office_seq
     NO MINVALUE
     MAXVALUE 2147483647
     CACHE 1;
-SET default_with_oids = true;
 CREATE TABLE member_officer (
     member_officerid integer DEFAULT nextval(('"member_office_member_office_seq"'::text)::regclass) NOT NULL,
     officerid integer NOT NULL,
@@ -1347,13 +1334,11 @@ CREATE TABLE member_officer (
     from_date date NOT NULL,
     till_date date
 );
-SET default_with_oids = false;
 CREATE TABLE member_pass (
     memberid integer NOT NULL,
     password character varying
 );
 COMMENT ON TABLE member_pass IS 'User password. Access only to be granted to Shibbobleh, Dovecot Users. Exim authenticates via IMAP.';
-SET default_with_oids = true;
 CREATE TABLE member_presenterstatus (
     memberid integer NOT NULL,
     presenterstatusid integer NOT NULL,
@@ -1375,7 +1360,6 @@ CREATE TABLE member_year (
     year smallint NOT NULL,
     paid numeric(4,2) DEFAULT 0 NOT NULL
 );
-SET default_with_oids = false;
 CREATE TABLE net_switchport (
     portid integer NOT NULL,
     vlanid integer,
@@ -1415,7 +1399,6 @@ CREATE TABLE nipsweb_migrate (
     enforced boolean DEFAULT false
 );
 COMMENT ON TABLE nipsweb_migrate IS 'Used to migrate users from BAPSWeb to NIPSWeb.';
-SET default_with_oids = true;
 CREATE TABLE officer (
     officerid integer DEFAULT nextval(('"officer_officerid_seq"'::text)::regclass) NOT NULL,
     officer_name character varying(255) NOT NULL,
@@ -1446,7 +1429,6 @@ CREATE TABLE rec_genrelookup (
     genre_code character(1) NOT NULL,
     genre_descr text NOT NULL
 );
-SET default_with_oids = false;
 CREATE TABLE rec_itunes (
     trackid integer NOT NULL,
     link text,
@@ -1455,7 +1437,6 @@ CREATE TABLE rec_itunes (
     identifier text
 );
 COMMENT ON TABLE rec_itunes IS 'itunes affiliation program';
-SET default_with_oids = true;
 CREATE TABLE rec_labelqueue (
     recordid integer,
     queueid integer DEFAULT nextval(('"rec_labelqueue_queueid_seq"'::text)::regclass) NOT NULL,
@@ -1471,7 +1452,6 @@ CREATE TABLE rec_locationlookup (
     location_code character(1) NOT NULL,
     location_descr text NOT NULL
 );
-SET default_with_oids = false;
 CREATE TABLE rec_lookup (
     code_type text NOT NULL,
     code character(1) NOT NULL,
@@ -1488,7 +1468,6 @@ CREATE SEQUENCE rec_lookup_description_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE rec_lookup_description_seq OWNED BY rec_lookup.description;
-SET default_with_oids = true;
 CREATE TABLE rec_medialookup (
     media_code character(1) NOT NULL,
     media_descr text NOT NULL
@@ -1528,7 +1507,6 @@ CREATE SEQUENCE rec_track_trackid_seq
     NO MINVALUE
     MAXVALUE 2147483647
     CACHE 1;
-SET default_with_oids = false;
 CREATE TABLE rec_trackcorrection (
     correctionid integer NOT NULL,
     trackid integer NOT NULL,
@@ -1590,9 +1568,7 @@ COMMENT ON COLUMN show_metadata.memberid IS 'The ID of the member who submitted 
 COMMENT ON COLUMN show_metadata.approvedid IS 'The ID of the member who approved the change to the show metadata item. A value of NULL means not yet approved or this item does not need to be approved.';
 COMMENT ON COLUMN show_metadata.effective_to IS 'The timestamp of the period at which this metadatum stops being effective.  If NULL, the metadatum is effective indefinitely from effective_from.';
 SET search_path = public, pg_catalog;
-SET default_with_oids = true;
 SET search_path = schedule, pg_catalog;
-SET default_with_oids = false;
 CREATE TABLE show_season (
     show_season_id integer NOT NULL,
     show_id integer NOT NULL,
@@ -1638,13 +1614,11 @@ CREATE SEQUENCE selector_selid_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE selector_selid_seq OWNED BY selector.selid;
-SET default_with_oids = false;
 CREATE TABLE sso_session (
     id character varying(32) NOT NULL,
     data text,
     "timestamp" timestamp without time zone NOT NULL
 );
-SET default_with_oids = true;
 CREATE TABLE strm_useragent (
     useragentid integer NOT NULL,
     useragent character varying(255) NOT NULL
@@ -1709,7 +1683,6 @@ CREATE SEQUENCE team_teamid_seq
     NO MINVALUE
     MAXVALUE 2147483647
     CACHE 1;
-SET default_with_oids = false;
 CREATE TABLE terms (
     start timestamp with time zone NOT NULL,
     descr character varying(10) NOT NULL,

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,8 +15,8 @@ apt-get update
 apt-get install -y apache2 \
 	libapache2-mod-php \
 	php-common \
-	postgresql-11 \
-	postgresql-client-11 \
+	postgresql-12 \
+	postgresql-client-12 \
 	memcached \
 	php-curl \
 	php-geoip \
@@ -37,7 +37,7 @@ a2enmod ssl
 a2enmod rewrite
 service apache2 stop
 
-cat <<EOF >> /etc/php/7.3/mods-available/xdebug.ini
+cat <<EOF >> /etc/php/7.4/mods-available/xdebug.ini
 xdebug.default_enable=1
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
@@ -80,9 +80,9 @@ update-rc.d apache2 defaults
 service apache2 start
 
 # Create DB cluster/database/user
-pg_dropcluster 11 main --stop || true # Seriously, don't use this anywhere other than vagrant
-if ! `pg_lsclusters | grep -q myradio`; then pg_createcluster 11 myradio -p 5432; fi
-systemctl start postgresql@11-myradio
+pg_dropcluster 12 main --stop || true # Seriously, don't use this anywhere other than vagrant
+if ! `pg_lsclusters | grep -q myradio`; then pg_createcluster 12 myradio -p 5432; fi
+systemctl start postgresql@12-myradio
 su - postgres -c "cat /vagrant/sample_configs/postgres.sql | psql"
 
 rm -f /vagrant/src/MyRadio_Config.local.php # Remove any existing config

--- a/scripts/reset-db-preSetup.sh
+++ b/scripts/reset-db-preSetup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# Resets the main database - do not run this anywhere important
+
+[[ -z $1 ]] && db="myradio_test" || db="myradio"
+
+dropdb --if-exists $db;
+createdb -O myradio $db

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -13,7 +13,7 @@ use \MyRadio\MyRadio\MyRadioNullSession;
  * This number is incremented every time a database patch is released.
  * Patches are scripts in schema/patches.
  */
-define('MYRADIO_CURRENT_SCHEMA_VERSION', 0);
+define('MYRADIO_CURRENT_SCHEMA_VERSION', 11);
 
 /*
  * Turn on Error Reporting for the start. Once the Config object is loaded


### PR DESCRIPTION
- Do basic version updates for postgres and php
- Remove oids from base.sql - Closes #1037 
- Create basic bash script to wipe database cleanly (so you can edit the setup scripts without rerunning `vagrant up` each time)
- Set MYRADIO_CURRENT_SCHEMA_VERSION to the latest patch version (which I think we were meant to have been doing, since that's how it sees whether to install patches)
- Create a loop in dbschema because it has an issue where it applies base.sql but then, on the next query, doesn't seem to be able to find its changes in the database. This makes it repeat maybe 3 times but limits the amount a user has to do to get it working (which is a fair compromise)
- Other minor edits to dbschema to avoid weird unexpected cases