### PR TITLE
Training cut-off + people limit (fixes #1049, fixes #1052)

### DIFF
--- a/schema/patches/12.sql
+++ b/schema/patches/12.sql
@@ -3,4 +3,7 @@ BEGIN;
 ALTER TABLE schedule.demo
     ADD COLUMN signup_cutoff_hours INT DEFAULT 0;
 
+ALTER TABLE schedule.demo
+    ADD COLUMN max_participants INT DEFAULT 2;
+
 COMMIT;

--- a/schema/patches/12.sql
+++ b/schema/patches/12.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE schedule.demo
+    ADD COLUMN signup_cutoff_hours INT DEFAULT 0;
+
+COMMIT;

--- a/src/Classes/ServiceAPI/MyRadio_Demo.php
+++ b/src/Classes/ServiceAPI/MyRadio_Demo.php
@@ -196,7 +196,11 @@ class MyRadio_Demo extends ServiceAPI
                     'label' => "Signup Cutoff (Hours)",
                     'explanation' => 'If set, people will only be able to join this many hours before your session starts. Set to 0 to disable.',
                     "required" => false,
-                    'min' => 0
+                    'options' => [
+                        'min' => 0,
+                    ],
+                    'value' => 0,
+                    'required' => true
                 ]
             )
         )->addField(

--- a/src/Classes/ServiceAPI/MyRadio_Demo.php
+++ b/src/Classes/ServiceAPI/MyRadio_Demo.php
@@ -27,6 +27,7 @@ class MyRadio_Demo extends ServiceAPI
     private $demo_link;
     private $presenterstatusid;
     private $memberid;
+    private $signup_cutoff_hours;
 
     protected function __construct($demoid)
     {
@@ -48,6 +49,7 @@ class MyRadio_Demo extends ServiceAPI
         $this->demo_link = $result['demo_link'];
         $this->presenterstatusid = $result['presenterstatusid'];
         $this->memberid = $result["memberid"];
+        $this->signup_cutoff_hours = (int) $result['signup_cutoff_hours'];
     }
 
     public function getID()
@@ -55,7 +57,7 @@ class MyRadio_Demo extends ServiceAPI
         return $this->demo_id;
     }
 
-    public static function registerDemo($time, $training_type, $link = null)
+    public static function registerDemo($time, $training_type, $link = null, $signup_cutoff_hours = 0)
     {
         if ($time == null || $training_type == null || !is_numeric($time)) {
             throw new MyRadioException("A training demo must have a time and training date.", 400);
@@ -66,9 +68,9 @@ class MyRadio_Demo extends ServiceAPI
                 self::initDB();
 
                 self::$db->query(
-                    "INSERT INTO schedule.demo (presenterstatusid, demo_time, demo_link, memberid)
-            VALUES ($1, $2, $3, $4)",
-                    [$training_type, CoreUtils::getTimestamp($time), $link, $_SESSION["memberid"]]
+                    "INSERT INTO schedule.demo (presenterstatusid, demo_time, demo_link, memberid, signup_cutoff_hours)
+                    VALUES ($1, $2, $3, $4, $5)",
+                    [$training_type, CoreUtils::getTimestamp($time), $link, $_SESSION["memberid"], $signup_cutoff_hours]
                 );
                 date_default_timezone_set(Config::$timezone);
 
@@ -93,7 +95,7 @@ class MyRadio_Demo extends ServiceAPI
         return true;
     }
 
-    public function editDemo($time, $training_type, $link = null)
+    public function editDemo($time, $training_type, $link = null, $signup_cutoff_hours = 0)
     {
 
         // TODO, Only edit your training demos, or any if you have perms
@@ -105,9 +107,12 @@ class MyRadio_Demo extends ServiceAPI
             if ($time != $this->demo_time || $link != $this->demo_link || $training_type != $this->presenterstatusid) {
                 // Do the Update
                 self::$db->query(
-                    "UPDATE schedule.demo SET demo_time = $1, demo_link = $2, presenterstatusid = $3
-                WHERE demo_id = $4",
-                    [CoreUtils::getTimestamp($time), $link, $training_type, $this->getID()]
+                    "UPDATE schedule.demo SET demo_time = $1,
+                    demo_link = $2,
+                    presenterstatusid = $3,
+                    signup_cutoff_hours = $4
+                WHERE demo_id = $5",
+                    [CoreUtils::getTimestamp($time), $link, $training_type, $signup_cutoff_hours, $this->getID()]
                 );
                 // Email People
                 $attendees = $this->myRadioUsersAttendingDemo();
@@ -178,6 +183,17 @@ class MyRadio_Demo extends ServiceAPI
                     "required" => false
                 ]
             )
+        )->addField(
+            new MyRadioFormField(
+                'signup_cutoff_hours',
+                MyRadioFormField::TYPE_NUMBER,
+                [
+                    'label' => "Signup Cutoff (Hours)",
+                    'explanation' => 'If set, people will only be able to join this many hours before your session starts. Set to 0 to disable.',
+                    "required" => false,
+                    'min' => 0
+                ]
+            )
         );
     }
 
@@ -190,7 +206,8 @@ class MyRadio_Demo extends ServiceAPI
                 [
                     "demo_training_type" => $this->getTrainingType()->getID(),
                     "demo_datetime" => CoreUtils::happyTime($this->getDemoTime()),
-                    "demo_link" => $this->getLink()
+                    "demo_link" => $this->getLink(),
+                    'signup_cutoff_hours' => $this->signup_cutoff_hours
                 ]
             );
     }
@@ -208,6 +225,14 @@ class MyRadio_Demo extends ServiceAPI
     public function isSpaceOnDemo()
     {
         return $this->attendingDemoCount() < 2;
+    }
+
+    public function tooCloseToStart()
+    {
+        if ($this->signup_cutoff_hours === 0) {
+            return false;
+        }
+        return time() > ($this->demo_time - ($this->signup_cutoff_hours * 60 * 60));
     }
 
     // Grrr...this returns names, not users.
@@ -283,6 +308,7 @@ class MyRadio_Demo extends ServiceAPI
      * Return 0: Success
      * Return 1: Demo Full
      * Return 2: Already Attending a Demo.
+     * Return 3: Too Late.
      */
     public function attend()
     {
@@ -301,6 +327,10 @@ class MyRadio_Demo extends ServiceAPI
             [$_SESSION['memberid'], $this->presenterstatusid]
         )) !== 0) {
             return 2;
+        }
+
+        if ($this->tooCloseToStart()) {
+            return 3;
         }
 
         self::$db->query(
@@ -343,9 +373,14 @@ class MyRadio_Demo extends ServiceAPI
 
     /**
      * The current user is unmarked as attending a demo.
+     * Returns 0: successful
+     * Returns 3: too late, need to contact trainer
      */
     public function leave()
     {
+        if ($this->tooCloseToStart()) {
+            return 3;
+        }
 
         self::$db->query(
             "DELETE FROM schedule.demo_attendee

--- a/src/Controllers/Training/createDemo.php
+++ b/src/Controllers/Training/createDemo.php
@@ -15,11 +15,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         MyRadio_Demo::getInstance($demoinfo['id'])->editDemo(
             $demoinfo['demo_datetime'],
             $demoinfo['demo_training_type'],
-            $demoinfo['demo_link']
+            $demoinfo['demo_link'],
+            $demoinfo['signup_cutoff_hours']
         );
     } else {
         // Create a New Demo
-        MyRadio_Demo::registerDemo($demoinfo['demo_datetime'], $demoinfo['demo_training_type'], $demoinfo['demo_link']);
+        MyRadio_Demo::registerDemo($demoinfo['demo_datetime'], $demoinfo['demo_training_type'], $demoinfo['demo_link'], $demoinfo['signup_cutoff_hours']);
     }
     URLUtils::backWithMessage('Session Updated!');
 } else {

--- a/src/Controllers/Training/createDemo.php
+++ b/src/Controllers/Training/createDemo.php
@@ -15,12 +15,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         MyRadio_Demo::getInstance($demoinfo['id'])->editDemo(
             $demoinfo['demo_datetime'],
             $demoinfo['demo_training_type'],
+            $demoinfo['demo_max_participants'],
             $demoinfo['demo_link'],
             $demoinfo['signup_cutoff_hours']
         );
     } else {
         // Create a New Demo
-        MyRadio_Demo::registerDemo($demoinfo['demo_datetime'], $demoinfo['demo_training_type'], $demoinfo['demo_link'], $demoinfo['signup_cutoff_hours']);
+        MyRadio_Demo::registerDemo($demoinfo['demo_datetime'], $demoinfo['demo_training_type'], $demoinfo['demo_max_participants'], $demoinfo['demo_link'], $demoinfo['signup_cutoff_hours']);
     }
     URLUtils::backWithMessage('Session Updated!');
 } else {

--- a/src/Controllers/Training/leaveDemo.php
+++ b/src/Controllers/Training/leaveDemo.php
@@ -3,5 +3,5 @@
 use \MyRadio\MyRadio\URLUtils;
 use \MyRadio\ServiceAPI\MyRadio_Demo;
 
-MyRadio_Demo::getInstance($_REQUEST['demoid'])->leave();
-URLUtils::redirect($module, 'listDemos', ['msg' => 3]); // 3 means left... see listDemos.php
+$result = MyRadio_Demo::getInstance($_REQUEST['demoid'])->leave();
+URLUtils::redirect($module, 'listDemos', ['msg' => $result === 0 ? -1 : $result * -1]); // -1 means left... see listDemos.php

--- a/src/Controllers/Training/listDemos.php
+++ b/src/Controllers/Training/listDemos.php
@@ -98,7 +98,7 @@ if (isset($_REQUEST['msg'])) {
             $twig->addInfo('You have successfully been added to this session.');
             break;
         case 1: //full
-            $twig->addError('Sorry, but a maximum two people can join a session.');
+            $twig->addError('Sorry, but too many people are already attending this session.');
             break;
         case 2: //attending already
             $twig->addError('You can only attend one session for that training at a time.');

--- a/src/Controllers/Training/listDemos.php
+++ b/src/Controllers/Training/listDemos.php
@@ -32,19 +32,33 @@ foreach ($demos as $demo) {
         ];
     } else {
         if ($demo_object->isUserAttendingDemo($currentUser->getID())) {
-            $demo['attending'] = 'You are attending this demo';
-            $demo['join'] = [
-                'display' => 'text',
-                'value' => 'Leave',
-                'url' => URLUtils::makeURL('Training', 'leaveDemo', ['demoid' => $demo['demo_id']]),
-            ];
+            if ($demo_object->tooCloseToStart()) {
+                $demo['attending'] = 'You are attending this demo. Please contact your trainer if you can no longer make it.';
+                $demo['join'] = [
+                    'display' => 'none',
+                ];
+            } else {
+                $demo['attending'] = 'You are attending this demo';
+                $demo['join'] = [
+                    'display' => 'text',
+                    'value' => 'Leave',
+                    'url' => URLUtils::makeURL('Training', 'leaveDemo', ['demoid' => $demo['demo_id']]),
+                ];
+            }
         } elseif ($demo_object->isSpaceOnDemo()) {
-            $demo['attending'] = 'Space available!';
-            $demo['join'] = [
-                'display' => 'text',
-                'value' => 'Join',
-                'url' => URLUtils::makeURL('Training', 'attendDemo', ['demoid' => $demo['demo_id']]),
-            ];
+            if ($demo_object->tooCloseToStart()) {
+                $demo['attending'] = 'Too late to sign up';
+                $demo['join'] = [
+                    'display' => 'none',
+                ];
+            } else {
+                $demo['attending'] = 'Space available!';
+                $demo['join'] = [
+                    'display' => 'text',
+                    'value' => 'Join',
+                    'url' => URLUtils::makeURL('Training', 'attendDemo', ['demoid' => $demo['demo_id']]),
+                ];
+            }
         } else {
             $demo['attending'] = 'Demo full';
             $demo['join'] = ['display' => 'none'];
@@ -89,8 +103,14 @@ if (isset($_REQUEST['msg'])) {
         case 2: //attending already
             $twig->addError('You can only attend one session for that training at a time.');
             break;
-        case 3: // Left session
+        case 3: //too late
+            $twig->addError('It is now too late to join this session. If you still wish to attend, please contact the trainer directly to see if there is space available.');
+            break;
+        case -1: // Left session
             $twig->addInfo('You have left the training session.');
+            break;
+        case -3: //too late
+            $twig->addError('It is now too late to leave this session. If you cannot make it, please contact the trainer directly.');
             break;
         case 4: // Mark attendees as trained
             $twig->addInfo("You have marked the attendees as trained.");

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -13,7 +13,7 @@ use \MyRadio\MyRadio\MyRadioNullSession;
  * This number is incremented every time a database patch is released.
  * Patches are scripts in schema/patches.
  */
-define('MYRADIO_CURRENT_SCHEMA_VERSION', 11);
+define('MYRADIO_CURRENT_SCHEMA_VERSION', 12);
 
 /*
  * Turn on Error Reporting for the start. Once the Config object is loaded


### PR DESCRIPTION
Make the cutoff configurable, so that people can set it accordingly - early morning sessions may want notice, while people who are going to be at the station anyway don'ŧ really mind.

Screenshots in action (on my local dev environment):
![image](https://user-images.githubusercontent.com/2904440/151435218-0e1680af-a70c-4594-8e5a-37ad8ac174c6.png)
![image](https://user-images.githubusercontent.com/2904440/151435273-443479bf-0556-4006-a8f9-44c04b7562ee.png)
![image](https://user-images.githubusercontent.com/2904440/151435326-054eb270-442e-40ae-b578-e26d86e924c2.png)

Also merged with @hicks927's work on setting an attendee limit, because it makes sense to do them at the same time:

![image](https://user-images.githubusercontent.com/2904440/154157907-06af53a1-16aa-4a72-8011-9bab346c8bfc.png)
![image](https://user-images.githubusercontent.com/2904440/154157833-9f6363ac-da70-451d-a73a-570d516cf349.png)
