### PR TITLE
Allow archiving a training status

### DIFF
--- a/schema/patches/15.sql
+++ b/schema/patches/15.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE public.l_presenterstatus
+    ADD COLUMN archived BOOLEAN DEFAULT 'f';
+
+COMMIT;

--- a/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
@@ -233,11 +233,7 @@ class MyRadio_TrainingStatus extends ServiceAPI
             return true;
         }
 
-        if (!$this->getAwarder()->isAwardedTo($user)) {
-            return false;
-        }
-
-        return true;
+        return $this->getAwarder()->isAwardedTo($user);
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
@@ -182,7 +182,7 @@ class MyRadio_TrainingStatus extends ServiceAPI
      */
     public function getDepends()
     {
-        return empty($this->depends) ? null : self::getInstance($this->depends);
+        return empty($this->depends) ? null : MyRadio_TrainingStatus::getInstance($this->depends);
     }
 
     /**
@@ -208,7 +208,7 @@ class MyRadio_TrainingStatus extends ServiceAPI
      */
     public function getAwarder()
     {
-        return self::getInstance($this->can_award);
+        return MyRadio_TrainingStatus::getInstance($this->can_award);
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_TrainingStatus.php
@@ -212,7 +212,11 @@ class MyRadio_TrainingStatus extends ServiceAPI
             return true;
         }
 
-        return $this->getAwarder()->isAwardedTo($user);
+        if (!$this->getAwarder()->isAwardedTo($user)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Classes/ServiceAPI/MyRadio_UserTrainingStatus.php
+++ b/src/Classes/ServiceAPI/MyRadio_UserTrainingStatus.php
@@ -205,29 +205,11 @@ class MyRadio_UserTrainingStatus extends MyRadio_TrainingStatus
             $awarded_by = MyRadio_User::getInstance();
         }
 
-        //Check whether this user can do that.
-        if (in_array(
-            array_map(
-                function ($x) {
-                    return $x->getID();
-                },
-                $awarded_by->getAllTraining(true)
-            ),
-            $status->getAwarder()->getID()
-        ) === false) {
+        if (!$status->canAward($awarded_by)) {
             throw new MyRadioException($awarded_by.' does not have permission to award '.$status);
         }
 
-        //Check whether the target user has the prerequisites
-        if ($status->getDepends() !== null and in_array(
-            $status->getDepends()->getID(),
-            array_map(
-                function ($x) {
-                    return $x->getID();
-                },
-                $awarded_to->getAllTraining(true)
-            )
-        ) === false) {
+        if ($status->hasDependency($awarded_to)) {
             throw new MyRadioException($awarded_to.' does not have the prerequisite training to be awarded '.$status);
         }
 

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -13,7 +13,7 @@ use \MyRadio\MyRadio\MyRadioNullSession;
  * This number is incremented every time a database patch is released.
  * Patches are scripts in schema/patches.
  */
-define('MYRADIO_CURRENT_SCHEMA_VERSION', 14);
+define('MYRADIO_CURRENT_SCHEMA_VERSION', 15);
 
 /*
  * Turn on Error Reporting for the start. Once the Config object is loaded


### PR DESCRIPTION
An archived training status can still be seen for anyone who already has it, but can't be newly given.

Tested locally in Docker.
