### PR TITLE
Hide "Edit Season" link

### DIFF
--- a/src/Public/js/myradio.scheduler.seasonlist.js
+++ b/src/Public/js/myradio.scheduler.seasonlist.js
@@ -38,8 +38,8 @@ $(".twig-datatable").dataTable({
     },
     //editlink
     {
-      "sTitle": "Edit",
-      "bVisible": true
+      //"sTitle": "Edit",
+      "bVisible": false
     },
     //applylink
     {


### PR DESCRIPTION
It hasn't worked in years, so let's avoid people clicking it and wondering why things broke.