### PR TITLE
fix userSelectedTimeslot

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -458,6 +458,7 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
 
         //Note the ordering is important - create is static!
         if ($name === 'testCredentials'
+            || $name === 'setUserSelectedTimeslot'
             || CoreUtils::startsWith($name, 'create')
             || CoreUtils::startsWith($name, 'add')
         ) {

--- a/src/Classes/ServiceAPI/MyRadio_Swagger2.php
+++ b/src/Classes/ServiceAPI/MyRadio_Swagger2.php
@@ -457,6 +457,8 @@ class MyRadio_Swagger2 extends MyRadio_Swagger
         $name = $method->getName();
 
         //Note the ordering is important - create is static!
+        // setUserSelectedTimeslot is here too because it's a static
+        // method setting a 'global' (in the session) variable
         if ($name === 'testCredentials'
             || $name === 'setUserSelectedTimeslot'
             || CoreUtils::startsWith($name, 'create')


### PR DESCRIPTION
because of `setUserSelectedTimeslot` being static (because it sets it in the session), it considers it the GET method.

By pure chance in the last 2.5 years, when going through the methods, it looked at setUST first, said it was the get method, then saw getUST and overwrote that as the GET method, but now it's seeing them in the other order, so overwrites getUST with setUST as the GET method. Because there's no ordering to the methods [I assume], just the order they happen to be returned in, and we've been relying on getUST coming second.

I put it in as an edge case cause it kinda is - static method setting a thing essentially 'globally'