### PR TITLE
Temp fix to password reset email in MyRadioDefaultAuthenticator.php

### DIFF
--- a/src/Classes/MyRadio/MyRadioDefaultAuthenticator.php
+++ b/src/Classes/MyRadio/MyRadioDefaultAuthenticator.php
@@ -154,8 +154,8 @@ class MyRadioDefaultAuthenticator extends \MyRadio\Database implements \MyRadio\
             .'<p>A password reset has been requested for the '.Config::$short_name
             .' account associated with this email address. If you did not request'
             .' this email, please ignore it.</p>'
-            .'<p><a href="'.URLUtils::makeURL('MyRadio', 'pwChange', ['token' => $token])
-            .'">Click here to finish resetting your password.</a></p>'
+            .'<p>'.URLUtils::makeURL('MyRadio', 'pwChange', ['token' => $token])
+            .'Copy that link and paste it into your searchbar to finish resetting your password.</p>'
         );
 
         return true;

--- a/src/Classes/MyRadio/MyRadioDefaultAuthenticator.php
+++ b/src/Classes/MyRadio/MyRadioDefaultAuthenticator.php
@@ -154,8 +154,8 @@ class MyRadioDefaultAuthenticator extends \MyRadio\Database implements \MyRadio\
             .'<p>A password reset has been requested for the '.Config::$short_name
             .' account associated with this email address. If you did not request'
             .' this email, please ignore it.</p>'
-            .'<p>'.URLUtils::makeURL('MyRadio', 'pwChange', ['token' => $token])
-            .'Copy that link and paste it into your searchbar to finish resetting your password.</p>'
+            .'<p>'.URLUtils::makeURL('MyRadio', 'pwChange', ['token' => $token]).'</p>'
+            .'<p>Copy that link and paste it into your searchbar to finish resetting your password.</p>'
         );
 
         return true;


### PR DESCRIPTION
Removed the html hyperlink tag to make the reset link appear in plain text so that people can still reset their passwords while comp team fix the email formatting problem