### PR TITLE
Upgrade development Dockerfile to PHP 8 + setup fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.1-apache
 
 RUN apt-get update && apt-get install -y libpq-dev libpng-dev libjpeg-dev libldap-dev unzip \
                                          libcurl4-openssl-dev libxslt-dev git libz-dev libzip-dev libmemcached-dev \
@@ -10,7 +10,7 @@ RUN pecl install memcached && \
     echo extension=memcached.so >> /usr/local/etc/php/conf.d/memcached.ini
 
 RUN pecl install xdebug-3.1.1 && docker-php-ext-enable xdebug \
- && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so"' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+ && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so"' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
  && echo 'xdebug.client_port=9003' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
  && echo 'xdebug.mode=develop,debug' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
  && echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.2-apache
 
 RUN apt-get update && apt-get install -y libpq-dev libpng-dev libjpeg-dev libldap-dev unzip \
                                          libcurl4-openssl-dev libxslt-dev git libz-dev libzip-dev libmemcached-dev \
@@ -9,8 +9,8 @@ RUN docker-php-ext-install pgsql pdo_pgsql gd ldap curl xsl zip
 RUN pecl install memcached && \
     echo extension=memcached.so >> /usr/local/etc/php/conf.d/memcached.ini
 
-RUN pecl install xdebug-3.1.1 && docker-php-ext-enable xdebug \
- && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so"' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+RUN pecl install xdebug-3.3.1 && docker-php-ext-enable xdebug \
+ && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20220829/xdebug.so"' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
  && echo 'xdebug.client_port=9003' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
  && echo 'xdebug.mode=develop,debug' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
  && echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="MyRadio" default="build">
  <property name="vendordir" value="${basedir}/src/vendor/bin" />
- <target name="build" depends="prepare,composer,lint,phploc,pdepend,phpmd-ci,phpcs-ci,eslint-ci,phpcpd,phpdox"/>
+ <target name="build" depends="prepare,composer,lint,pdepend,phpmd-ci,phpcs-ci,eslint-ci,phpdox"/>
 
  <target name="clean" description="Cleanup build artifacts">
   <delete dir="${basedir}/build/api"/>
@@ -43,18 +43,6 @@
    </fileset>
    -->
   </apply>
- </target>
-
- <target name="phploc" description="Measure project size using PHPLOC">
-  <exec executable="${vendordir}/phploc">
-   <arg value="--count-tests" />
-   <arg value="--log-csv" />
-   <arg value="${basedir}/build/logs/phploc.csv" />
-   <arg value="--log-xml" />
-   <arg value="${basedir}/build/logs/phploc.xml" />
-   <arg value="--exclude=vendor" />
-   <arg path="${basedir}/src" />
-  </exec>
  </target>
 
  <target name="pdepend" description="Calculate software metrics using PHP_Depend">
@@ -99,14 +87,6 @@
    <arg value="--format=checkstyle" />
    <arg value="--output-file=${basedir}/build/logs/eslint.xml" />
    <arg path="${basedir}/src/Public/js" />
-  </exec>
- </target>
-
- <target name="phpcpd" description="Find duplicate code using PHPCPD">
-  <exec executable="${vendordir}/phpcpd">
-   <arg value="--log-pmd=${basedir}/build/logs/pmd-cpd.xml" />
-   <arg value="--exclude=vendor" />
-   <arg path="${basedir}/src" />
   </exec>
  </target>
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": ">=7.4 <8.0",
+        "php": ">=7.4",
         "james-heinrich/getid3": "~1.9",
         "ezyang/htmlpurifier": "~4.10",
         "google/recaptcha": "~1.1",
@@ -10,16 +10,15 @@
         "webonyx/graphql-php": "^0.13.8",
         "ext-json": "*",
         "geoip2/geoip2": "^2.10.0",
-        "spatie/icalendar-generator": "^2.1"
+        "spatie/icalendar-generator": "^2.1",
+        "ext-pgsql": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~3.5",
         "pdepend/pdepend": "~2.5",
         "phpmd/phpmd": "~2.6",
-        "sebastian/phpcpd": "~3.0",
-        "phploc/phploc": "~4.0",
         "theseer/phpdox": "~0.11",
-        "codeception/codeception": "~2.4",
+        "codeception/codeception": "~4.2",
         "flow/jsonpath": "~0.4"
     },
     "config": {

--- a/schema/patches/18.sql
+++ b/schema/patches/18.sql
@@ -1,5 +1,8 @@
 CREATE TYPE deletion AS ENUM ('default', 'informed', 'optout', 'deleted');
 
+ALTER TABLE public.member
+    ADD gdpr_accepted boolean default(false);
+
 ALTER TABLE Public.member
 ADD data_removal deletion DEFAULT('default');
 

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,0 +1,2 @@
+ALTER TABLE schedule.show
+ADD podcast_explicit BOOLEAN DEFAULT(false);

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,2 +1,0 @@
-ALTER TABLE schedule.show
-ADD podcast_explicit BOOLEAN DEFAULT(false);

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -126,7 +126,11 @@ class Database
             pg_send_query_params($this->db, $sql, $params);
         }
         $result = pg_get_result($this->db);
-        $errmsg = pg_result_error($result);
+        if ($result === FALSE) {
+            $errmsg = pg_last_error($this->db);
+        } else {
+            $errmsg = pg_result_error($result);
+        }
         if ($errmsg != "") {
             if ($this->in_transaction) {
                 pg_query($this->db, 'ROLLBACK');

--- a/src/Classes/MyRadio/AuthUtils.php
+++ b/src/Classes/MyRadio/AuthUtils.php
@@ -406,8 +406,10 @@ class AuthUtils
     public static function addPermission($descr, $constant)
     {
         $value = (int) Database::getInstance()->fetchColumn(
+            // This is for all intents and purposes an ON CONFLICT DO NOTHING, but if we did use that
+            // then the RETURNING wouldn't return the ID which we need, hence the no-op UPDATE.
             'INSERT INTO public.l_action (descr, phpconstant)
-            VALUES ($1, $2) RETURNING typeid',
+            VALUES ($1, $2) ON CONFLICT (phpconstant) DO UPDATE SET descr = $1 RETURNING typeid',
             [$descr, $constant]
         )[0];
         define($constant, $value);
@@ -428,7 +430,8 @@ class AuthUtils
         $db = Database::getInstance();
         $db->query(
             'INSERT INTO myury.act_permission (serviceid, moduleid, actionid, typeid)
-            VALUES ($1, $2, $3, $4)',
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (serviceid, moduleid, actionid, typeid) DO NOTHING',
             [Config::$service_id, $module, $action, $permission]
         );
     }

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -13,7 +13,7 @@ use \MyRadio\MyRadio\MyRadioNullSession;
  * This number is incremented every time a database patch is released.
  * Patches are scripts in schema/patches.
  */
-define('MYRADIO_CURRENT_SCHEMA_VERSION', 19);
+define('MYRADIO_CURRENT_SCHEMA_VERSION', 18);
 
 /*
  * Turn on Error Reporting for the start. Once the Config object is loaded

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -13,7 +13,7 @@ use \MyRadio\MyRadio\MyRadioNullSession;
  * This number is incremented every time a database patch is released.
  * Patches are scripts in schema/patches.
  */
-define('MYRADIO_CURRENT_SCHEMA_VERSION', 15);
+define('MYRADIO_CURRENT_SCHEMA_VERSION', 19);
 
 /*
  * Turn on Error Reporting for the start. Once the Config object is loaded
@@ -56,7 +56,7 @@ require 'vendor/autoload.php';
  * Load configuration specific to this system.
  * Or, if it doesn't exist, kick into setup.
  */
-if (stream_resolve_include_path('MyRadio_Config.local.php')) {
+if (stream_resolve_include_path('MyRadio_Config.local.php') && file_exists(stream_resolve_include_path('MyRadio_Config.local.php'))) {
     require_once 'MyRadio_Config.local.php';
     if (Config::$setup === true) {
         require 'Controllers/Setup/root.php';
@@ -96,7 +96,7 @@ AuthUtils::setUpAuth();
  * Turn off visible error reporting, if needed
  * must come after AuthUtils::setUpAuth()
  */
-if (!Config::$display_errors && !AuthUtils::hasPermission(AUTH_SHOWERRORS)) {
+if (!Config::$display_errors && defined('AUTH_SHOWERRORS') && !AuthUtils::hasPermission(AUTH_SHOWERRORS)) {
     ini_set('display_errors', 'Off');
 }
 


### PR DESCRIPTION
Two changes in this PR:
* First upgrades the Dockerfile to PHP 8.2. I had to remove a bunch of dev-only Composer dependencies that don't support PHP 8 (and some don't exist at all anymore) - the only risky one is codeception which is a major version bump 
* Second onwards is all the changes I had to make to the setup flow to get it to succeed in one go - mainly making all the database operations idempotent and a few other smaller fixes.