### PR TITLE
Update myradio.scheduler.termlist.js to match new column ordering

### DIFF
--- a/src/Public/js/myradio.scheduler.termlist.js
+++ b/src/Public/js/myradio.scheduler.termlist.js
@@ -1,13 +1,9 @@
 $(".twig-datatable").dataTable({
-  "aaSorting": [[2, "desc"]],
+  "aaSorting": [[5, "desc"]],
   "aoColumns": [
     //termid
     {
       "bVisible": false
-    },
-    //start
-    {
-      "sTitle": "Start Date"
     },
     //descr
     {
@@ -20,6 +16,10 @@ $(".twig-datatable").dataTable({
     //week_names
     {
       "bVisible": false,
+    },
+    //start
+    {
+      "sTitle": "Start Date"
     }
   ],
   "bPaginate": true


### PR DESCRIPTION
Could potentialy be a non-determanistic type thing but everytime I set up a new myradio instance the manage terms page always lists term name and term id under Start Date and Name. This happens on new codespace builds but I can no longer check on ury.org.uk/myradio to verify. This is the only table to my knowledge with this issue.
![sched-wrong](https://github.com/UniversityRadioYork/MyRadio/assets/3528250/d99a5546-eed5-4943-959f-e86352e5b9ce)