### PR TITLE
Adding Nickname's to users and fixing some wordings on user profile to be line with gdpr

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -154,7 +154,7 @@ To do this, you first need to:
 
 ### Setting up your own 2016-site
 
-First pull 2016-site [2016-site](https://github.com/UniversityRadioYork/2016-site)
+First pull [2016-site](https://github.com/UniversityRadioYork/2016-site)
 
 Next you need a api_key to allow the website to access myradio's show information,
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -117,6 +117,9 @@ USER:
 -   [If you enter an @york.ac.uk email you will not be able to login at all]
 -   Login using the email and password you just enterted
 
+-   If you encounter an error you need to create the file /var/www/myradio/src/MyRadio_Config.local.php with the text from the "Show Config" button
+-   [if you are using docker this needs to be done within the docker container using `docker exec -it [myradioid] bash`]
+
 ## Default Credentials
 
 Database: (when building the database, these credentials are needed)

--- a/docs/install.md
+++ b/docs/install.md
@@ -152,7 +152,7 @@ To do this, you first need to:
 - Apply for a Season of your new Show (List My Shows -> New Season)
 - Schedule the Season (Shows Scheduler)
 
-# Setting up your own 2016-site
+### Setting up your own 2016-site
 
 To setup 2016-site:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,10 +24,18 @@ The codespace includes Mailhog, which will trap any emails sent by MyRadio. To s
 click the Local Address next to port 8025 in the Ports panel.
 
 ## Docker Install
+
 If you have Docker on your system, use Docker Compose to set up an environment.
-Simply run `docker compose up -d`, and visit "https://localhost:4443/myradio/".
+Simply run `docker compose up -d` and visit "https://localhost:4443/myradio/".
+
+If you encounter an error with autoload.php:
+find the id of your myradio container using `docker dontainer ls`
+enter a bash session with `docker exec -it [myradioid] bash`
+then in this session run `composer install`
+finally exit the session by running `exit`
 
 ## Vagrant Install
+
 MyRadio comes with a Vagrantfile based on Ubuntu 19.10.
 If you have [Vagrant](https://www.vagrantup.com) installed and want to get
 developing or playing right away, just run `vagrant up` and a few minutes
@@ -43,8 +51,9 @@ so be sure to never run this in a production environment, or remove the
 permission before doing so.
 
 ## Uncontained Install
+
 Install Apache2, PHP, Composer and PostgreSQL on your prefered Unix-based distro.
-Or Windows, if you're into that. 
+Or Windows, if you're into that.
 MyRadio has been tested with Ubuntu and FreeBSD.
 
 cd to your MyRadio installation and run `composer install`
@@ -74,6 +83,7 @@ Alias /api /usr/local/www/MyRadio/src/PublicAPI
 Restart Apache2, go to http://hostname/myradio
 
 To make a new postgresql server, run the following after:
+
 ```
 pg_createcluster [YOUR_POSTGRES_VERSION] myradio
 su postgres
@@ -85,36 +95,44 @@ CREATE DATABASE myradio WITH OWNER=myradio;
 # Post-Installation
 
 ## Myradio Setup
+
 CONNECT:
- - Open up "https://localhost:4443/myradio/" in a browser
- - [Use Chrome as this often fails to run on Firefox]
- - It will say "connection not private" so press "advanced" and then "proceed"
+
+-   Open up "https://localhost:4443/myradio/" in a browser
+-   [Use Chrome as this often fails to run on Firefox]
+-   It will say "connection not private" so press "advanced" and then "proceed"
 
 DATABASE:
- - On the intro screen press "Click here to continue"
- - Enter the database details (see Default Credentials) and press Next
- - Press "run task", wait a few seconds and then press "run task" again.
- - [This method is a workaround for a slight bug in how we build the database]
- 
+
+-   On the intro screen press "Click here to continue"
+-   Enter the database details (see Default Credentials) and press Next
+-   Press "run task", wait a few seconds and then press "run task" again.
+-   [This method is a workaround for a slight bug in how we build the database]
+
 USER:
- - [Here you can make config changes but the defaults are autofilled]
- - Press "complete starting set", scroll and press "save and continue"
- - Input any first and last name, an email (NOT an @york.ac.uk email) and a password
- - [If you enter an @york.ac.uk email you will not be able to login at all]
- - Login using the email and password you just enterted
+
+-   [Here you can make config changes but the defaults are autofilled]
+-   Press "complete starting set", scroll and press "save and continue"
+-   Input any first and last name, an email (NOT an @york.ac.uk email) and a password
+-   [If you enter an @york.ac.uk email you will not be able to login at all]
+-   Login using the email and password you just enterted
 
 ## Default Credentials
+
 Database: (when building the database, these credentials are needed)
- - Hostname: `postgres` if running in Docker, `localhost` otherwise
- - Database: myradio
- - Username: myradio
- - Password: myradio
+
+-   Hostname: `postgres` if running in Docker, `localhost` otherwise
+-   Database: myradio
+-   Username: myradio
+-   Password: myradio
 
 Vagrant VM: (if you need to ssh into the virtual machine)
- - Username: vagrant
- - Password: vagrant
+
+-   Username: vagrant
+-   Password: vagrant
 
 ## Tests
+
 MyRadio uses [Codeception](http://codeception.com/quickstart) for its test suite.
 
 [This was written with a Vagrant install in mind - has not been tested on Docker]
@@ -132,10 +150,11 @@ blanks the `myradio_test` database each time it is ran, so it can be used to
 reset the database and config file, should this prove necessary.
 
 Summary:
-* `composer install`
-* `vagrant up`
-* `vagrant ssh -- /vagrant/scripts/reset-db.sh`
-* `src/vendor/bin/codecept run`
+
+-   `composer install`
+-   `vagrant up`
+-   `vagrant ssh -- /vagrant/scripts/reset-db.sh`
+-   `src/vendor/bin/codecept run`
 
 The vagrant initialisation script also runs `composer install`, but that is run
 on the virtual machine which also installs the PHP extensions required for
@@ -143,20 +162,22 @@ Codeception. These extensions may be missing locally, so running composer will
 confirm that they are present.
 
 ## Next Steps
+
 Once you've got through the setup wizard, the next thing that's most useful to
 you is most likely creating a show.
 
 To do this, you first need to:
-- Create a Term (Show Scheduler -> Manage Terms)
-- Create a Show (List My Shows -> Create a Show)
-- Apply for a Season of your new Show (List My Shows -> New Season)
-- Schedule the Season (Shows Scheduler)
+
+-   Create a Term (Show Scheduler -> Manage Terms)
+-   Create a Show (List My Shows -> Create a Show)
+-   Apply for a Season of your new Show (List My Shows -> New Season)
+-   Schedule the Season (Shows Scheduler)
 
 ### Setting up your own 2016-site
 
 First pull [2016-site](https://github.com/UniversityRadioYork/2016-site)
 
-#### database 
+#### database
 
 Next you need a api_key to allow the website to access myradio's show information,
 
@@ -168,11 +189,12 @@ login into database with details used during setup of myradio
 
 [please choose a better key than 'ARANDOMSTRINGOFCHARACTERS']
 
-You might need add some other database columns to create shows 
+You might need add some other database columns to create shows
 
 for example:
-- explict podcasts (to create shows)
-- selector (expected by 2016-site/can remove this from models/index.go 2016-site) 
+
+-   explict podcasts (to create shows)
+-   selector (expected by 2016-site/can remove this from models/index.go 2016-site)
 
 2016-site uses parts of database that aren't made on myradio creation,
 
@@ -186,8 +208,7 @@ you can use setup guide in [2016-site](https://github.com/UniversityRadioYork/20
 And setup a reverse proxy to "https://localhost:4443/api/v2" or configure ssl for https connections
 To complete the setup.
 
-
 ### A note on Seasons and Terms
+
 MyRadio splits Shows into "Seasons". Any Season is applied to in relation to a
 "Term", which is a user defined space of time (normally 11-15 weeks). This is because The University of York has 12 week semesters, if you didn't know.
-

--- a/docs/install.md
+++ b/docs/install.md
@@ -152,7 +152,7 @@ To do this, you first need to:
 - Apply for a Season of your new Show (List My Shows -> New Season)
 - Schedule the Season (Shows Scheduler)
 
-## Setting up 2016-site - (setting up your own mini-ury)
+# Setting up your own 2016-site
 
 To setup 2016-site:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -157,6 +157,7 @@ To do this, you first need to:
 First pull 2016-site [2016-site](https://github.com/UniversityRadioYork/2016-site)
 
 Next you need a api_key to allow the website to access myradio's show information,
+
 login into database with details used during setup of myradio
 
 `INSERT INTO myury.api_key (key_string, description) VALUES ('ARANDOMSTRINGOFCHARACTERS', '2016-site development api key');`

--- a/docs/install.md
+++ b/docs/install.md
@@ -154,8 +154,6 @@ To do this, you first need to:
 
 ### Setting up your own 2016-site
 
-To setup 2016-site:
-
 First pull 2016-site [2016-site](https://github.com/UniversityRadioYork/2016-site)
 
 Next you need a api_key to allow the website to access myradio's show information,

--- a/docs/install.md
+++ b/docs/install.md
@@ -175,16 +175,6 @@ for example:
 - selector (expected by 2016-site/can remove this from models/index.go 2016-site) 
 
 2016-site uses parts of database that aren't made on myradio creation,
-such as mixcloud. This can cause issues with 2016-site not loading to fix this:
-
-#### uncomment existing myradio lines
-
-Go to:
-`src/Classes/ServiceAPI/MyRadio_Timeslot.php`
-
-- uncomment lines 379 and 380
-- comment lines 377 and 376
-
 
 #### finishing steps
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -156,6 +156,8 @@ To do this, you first need to:
 
 First pull [2016-site](https://github.com/UniversityRadioYork/2016-site)
 
+#### database 
+
 Next you need a api_key to allow the website to access myradio's show information,
 
 login into database with details used during setup of myradio
@@ -175,11 +177,16 @@ for example:
 2016-site uses parts of database that aren't made on myradio creation,
 such as mixcloud. This can cause issues with 2016-site not loading to fix this:
 
+#### uncomment existing myradio lines
+
 Go to:
 `src/Classes/ServiceAPI/MyRadio_Timeslot.php`
 
 - uncomment lines 379 and 380
 - comment lines 377 and 376
+
+
+#### finishing steps
 
 This will fix shows not loading on 2016-site when using the base myradio database
 
@@ -188,6 +195,7 @@ After completing all these setups:
 you can use setup guide in [2016-site](https://github.com/UniversityRadioYork/2016-site),
 And setup a reverse proxy to "https://localhost:4443/api/v2" or configure ssl for https connections
 To complete the setup.
+
 
 ### A note on Seasons and Terms
 MyRadio splits Shows into "Seasons". Any Season is applied to in relation to a

--- a/docs/install.md
+++ b/docs/install.md
@@ -152,8 +152,45 @@ To do this, you first need to:
 - Apply for a Season of your new Show (List My Shows -> New Season)
 - Schedule the Season (Shows Scheduler)
 
+## Setting up 2016-site - (setting up your own mini-ury)
+
+To setup 2016-site:
+
+First pull 2016-site [2016-site](https://github.com/UniversityRadioYork/2016-site)
+
+Next you need a api_key to allow the website to access myradio's show information,
+login into database with details used during setup of myradio
+
+`INSERT INTO myury.api_key (key_string, description) VALUES ('ARANDOMSTRINGOFCHARACTERS', '2016-site development api key');`
+
+`INSERT INTO myury.api_key_auth (key_string, typeid) VALUES ('ARANDOMSTRINGOFCHARACTERS', (SELECT typeid FROM l_action WHERE phpconstant = 'AUTH_APISUDO'));`
+
+[please choose a better key than 'ARANDOMSTRINGOFCHARACTERS']
+
+You might need add some other database columns to create shows 
+
+for example:
+- explict podcasts (to create shows)
+- selector (expected by 2016-site/can remove this from models/index.go 2016-site) 
+
+2016-site uses parts of database that aren't made on myradio creation,
+such as mixcloud. This can cause issues with 2016-site not loading to fix this:
+
+Go to:
+`src/Classes/ServiceAPI/MyRadio_Timeslot.php`
+
+- uncomment lines 379 and 380
+- comment lines 377 and 376
+
+This will fix shows not loading on 2016-site when using the base myradio database
+
+After completing all these setups:
+
+you can use setup guide in [2016-site](https://github.com/UniversityRadioYork/2016-site),
+And setup a reverse proxy to "https://localhost:4443/api/v2" or configure ssl for https connections
+To complete the setup.
+
 ### A note on Seasons and Terms
 MyRadio splits Shows into "Seasons". Any Season is applied to in relation to a
-"Term", which is a 10-week space of time. This is because The University of
-York has 12 week semesters, if you didn't know.
+"Term", which is a user defined space of time (normally 11-15 weeks). This is because The University of York has 12 week semesters, if you didn't know.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -155,5 +155,5 @@ To do this, you first need to:
 ### A note on Seasons and Terms
 MyRadio splits Shows into "Seasons". Any Season is applied to in relation to a
 "Term", which is a 10-week space of time. This is because The University of
-York has 10 week terms, if you didn't know.
+York has 12 week semesters, if you didn't know.
 

--- a/schema/api.graphql
+++ b/schema/api.graphql
@@ -99,6 +99,7 @@ type User implements Node & MyRadioObject {
     id: ID! @bind(method: "getID")
     itemId: Int! @bind(method: "getID")
     fname: String! @bind(method: "getFName")
+    nname: String! @bind(method: "getNName")
     sname: String! @bind(method: "getSName")
 
     # Public information
@@ -393,6 +394,7 @@ type EmailDestination {
 type MemberSearchResult {
     memberid: Int!
     fname: String!
+    nname: String!
     sname: String!
     eduroam: String
     local_alias: String

--- a/schema/api.json
+++ b/schema/api.json
@@ -116,6 +116,9 @@
                 "fname": {
                     "type": "string"
                 },
+                "nname": {
+                    "type": "string"
+                },
                 "sname": {
                     "type": "string"
                 },

--- a/schema/base.sql
+++ b/schema/base.sql
@@ -1257,7 +1257,7 @@ CREATE TABLE mail_list (
 COMMENT ON TABLE mail_list IS 'Definitions of mailing lists';
 COMMENT ON COLUMN mail_list.listid IS 'Surrogate Key';
 COMMENT ON COLUMN mail_list.listname IS 'Name of the list';
-COMMENT ON COLUMN mail_list.defn IS 'A SQL string that returns fname, sname and email address.';
+COMMENT ON COLUMN mail_list.defn IS 'A SQL string that returns fname, nname ,sname and email address.';
 COMMENT ON COLUMN mail_list.toexim IS 'Whether to create a mail alias on the email server for this list.';
 COMMENT ON COLUMN mail_list.listaddress IS 'If the list is exported, this is the list''s email address.';
 COMMENT ON COLUMN mail_list.subscribable IS 'Whether members can (un)subscribe freely.';
@@ -1276,6 +1276,7 @@ COMMENT ON TABLE mail_subscription IS 'If a list is subscribable, then all membe
 CREATE TABLE member (
     memberid integer DEFAULT nextval(('"member_memberid_seq"'::text)::regclass) NOT NULL,
     fname character varying(255) NOT NULL,
+    nname character varying(255),
     sname character varying(255) NOT NULL,
     college integer NOT NULL,
     phone character varying(255),

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,3 +1,2 @@
 ALTER TABLE member
-    ADD nname character varying(255),
-    
+    ADD nname character varying(255);

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,2 +1,7 @@
+BEGIN;
 ALTER TABLE member
     ADD nname character varying(255);
+UPDATE myradio.schema
+SET value = 19
+WHERE attr='version';
+COMMIT;

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,7 +1,4 @@
 BEGIN;
 ALTER TABLE member
     ADD nname character varying(255);
-UPDATE myradio.schema
-SET value = 19
-WHERE attr='version';
 COMMIT;

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member;
+ADD COLUMN nname VARCHAR(255);

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,2 +1,5 @@
 ALTER TABLE member
     ADD COLUMN nname character varying(255);
+
+INSERT INTO metadata.metadata_key VALUES (20,'upload_starttime',false,'In the case where a manual upload is required (because an event started late) will need to start late. This is a UTC time.',300,false);    
+INSERT INTO metadata.metadata_key VALUES (21,'upload_endtime',false,'In the case where a manual upload is required (because an event started late) will need to finish early/late.',300,false);

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,4 +1,4 @@
 BEGIN;
 ALTER TABLE member
-    ADD nname character varying(255);
+    ADD COLUMN nname character varying(255);
 COMMIT;

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,4 +1,2 @@
-BEGIN;
 ALTER TABLE member
     ADD COLUMN nname character varying(255);
-COMMIT;

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,2 +1,3 @@
 ALTER TABLE member
-    ADD COLUMN nname VARCHAR(255);
+    ADD nname character varying(255),
+    

--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,2 +1,2 @@
-ALTER TABLE member;
-ADD COLUMN nname VARCHAR(255);
+ALTER TABLE member
+    ADD COLUMN nname VARCHAR(255);

--- a/scripts/gdprdeleteuser.php
+++ b/scripts/gdprdeleteuser.php
@@ -40,7 +40,7 @@ echo "User selected for deletion: " . $userid . "\n";
 try{
     $db->query(
         'INSERT INTO public.member(
-            memberid, fname, sname, college, receive_email, data_removal)
+            memberid, fname, nname, sname, college, receive_email, data_removal)
             VALUES ($1, \'deleted\', \'user\', 10, false, \'deleted\')',
         [$deletedUserId]
     );

--- a/src/Classes/MyRadio/MyRadioNews.php
+++ b/src/Classes/MyRadio/MyRadioNews.php
@@ -75,7 +75,7 @@ class MyRadioNews
         $db = Database::getInstance();
 
         $news = $db->fetchOne(
-            'SELECT newsentryid, fname || \' "\' || nname || \'" \' || sname AS author, timestamp AS posted, content
+            'SELECT newsentryid, fname || \' \' || sname AS author, fname || \' "\' || nname || \'" \' || sname as nickname, timestamp AS posted, content
             FROM public.news_feed, public.member
             WHERE newsentryid=$1
             AND news_feed.memberid = member.memberid',

--- a/src/Classes/MyRadio/MyRadioNews.php
+++ b/src/Classes/MyRadio/MyRadioNews.php
@@ -75,7 +75,7 @@ class MyRadioNews
         $db = Database::getInstance();
 
         $news = $db->fetchOne(
-            'SELECT newsentryid, fname || \' \' || sname AS author, timestamp AS posted, content
+            'SELECT newsentryid, fname || \' "\' || nname || \'" \' || sname AS author, timestamp AS posted, content
             FROM public.news_feed, public.member
             WHERE newsentryid=$1
             AND news_feed.memberid = member.memberid',

--- a/src/Classes/ServiceAPI/MyRadio_Season.php
+++ b/src/Classes/ServiceAPI/MyRadio_Season.php
@@ -188,7 +188,7 @@ class MyRadio_Season extends MyRadio_Metadata_Common
          * Select an appropriate value for $term_id.
          */
         $term_id = MyRadio_Term::getActiveApplicationTerm()->getID();
-	$num_weeks = MyRadio_Term::getActiveApplicationTerm()->getTermWeeks();
+	    $num_weeks = MyRadio_Term::getActiveApplicationTerm()->getTermWeeks();
 
         //Start a transaction
         self::$db->query('BEGIN');

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -378,6 +378,8 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                 'mixcloud_starttime' => $this->getMeta('upload_starttime'),
                 'mixcloud_endtime' => $this->getMeta('upload_endtime'),
                 
+                //PLEASE REMOVE THIS COMMENTED WHEN USED IN DEVELOPMENT
+
                 //'mixcloud_starttime' => $this->getMeta('description'),
                 //'mixcloud_endtime' => $this->getMeta('description'),
                 'rejectlink' => [

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -373,8 +373,13 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                 'start_time' => CoreUtils::happyTime($this->getStartTime()),
                 'duration' => $this->getDuration(),
                 'mixcloud_status' => $this->getMeta('upload_state'),
+                //PLEASE REMOVE THIS COMMENTED WHEN USED IN PRODUCTION
+                
                 'mixcloud_starttime' => $this->getMeta('upload_starttime'),
                 'mixcloud_endtime' => $this->getMeta('upload_endtime'),
+                
+                //'mixcloud_starttime' => $this->getMeta('description'),
+                //'mixcloud_endtime' => $this->getMeta('description'),
                 'rejectlink' => [
                     'display' => 'icon',
                     'value' => 'trash',

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -373,13 +373,9 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                 'start_time' => CoreUtils::happyTime($this->getStartTime()),
                 'duration' => $this->getDuration(),
                 'mixcloud_status' => $this->getMeta('upload_state'),
-                //PLEASE REMOVE THIS COMMENTED WHEN USED IN PRODUCTION
-                
                 'mixcloud_starttime' => $this->getMeta('upload_starttime'),
                 'mixcloud_endtime' => $this->getMeta('upload_endtime'),
-                
-                //PLEASE REMOVE THIS COMMENTED WHEN USED IN DEVELOPMENT
-
+                //Remove this comment when in developement for 2016-site compatibility
                 //'mixcloud_starttime' => $this->getMeta('description'),
                 //'mixcloud_endtime' => $this->getMeta('description'),
                 'rejectlink' => [

--- a/src/Classes/ServiceAPI/MyRadio_Timeslot.php
+++ b/src/Classes/ServiceAPI/MyRadio_Timeslot.php
@@ -375,9 +375,6 @@ class MyRadio_Timeslot extends MyRadio_Metadata_Common
                 'mixcloud_status' => $this->getMeta('upload_state'),
                 'mixcloud_starttime' => $this->getMeta('upload_starttime'),
                 'mixcloud_endtime' => $this->getMeta('upload_endtime'),
-                //Remove this comment when in developement for 2016-site compatibility
-                //'mixcloud_starttime' => $this->getMeta('description'),
-                //'mixcloud_endtime' => $this->getMeta('description'),
                 'rejectlink' => [
                     'display' => 'icon',
                     'value' => 'trash',

--- a/src/Classes/ServiceAPI/MyRadio_Track.php
+++ b/src/Classes/ServiceAPI/MyRadio_Track.php
@@ -634,7 +634,11 @@ class MyRadio_Track extends ServiceAPI
 
         $title = htmlspecialchars($this->getTitle());
         $artist = htmlspecialchars($this->getArtist());
-        $userName = htmlspecialchars($currentUser->getFName() . ' ' . $currentUser->getSName());
+        if (empty($currentUser->getNName()) == True)  {
+            $userName = htmlspecialchars($currentUser->getFName() . ' ' . $currentUser->getSName());
+        } else {
+            $userName = htmlspecialchars($currentUser->getFName() . ' "' . $currentUser->getNName() . '" ' . $currentUser->getSName());
+        }
         $editUrl = URLUtils::makeURL('Library', 'editTrack', ['trackid' => $this->getID()]);
         MyRadioEmail::sendEmailToList(
             MyRadio_List::getByName('playlisting'),

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -947,6 +947,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         //If there's a space, split into first and last name
         $name = trim($name);
         $names = explode(' ', $name);
+        //Needs adapting to nname - TOBEFIXED
         if (isset($names[1])) {
             return self::$db->fetchAll(
                 'SELECT memberid, fname, nname, sname, eduroam, local_alias FROM member
@@ -1799,7 +1800,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
                 MyRadioFormField::TYPE_EMAIL,
                 [
                     'required' => false,
-                    'label' => 'Email',
+                    'label' => 'Public Email',
                     'value' => $this->email,
                 ]
             )
@@ -2472,7 +2473,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
             'nname' => $this->getNName(),
             'sname' => $this->getSName(),
             //Warning this will leak user emails to public as the api isn't secure
-            //'public_email' => $this->getPublicEmail(),
+            'public_email' => $this->getPublicEmail(),
             'url' => $this->getURL(),
             'receive_email' => $this->getReceiveEmail(),
             'contract_signed' => $this->hasSignedContract()

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -2471,7 +2471,8 @@ class MyRadio_User extends ServiceAPI implements APICaller
             'fname' => $this->getFName(),
             'nname' => $this->getNName(),
             'sname' => $this->getSName(),
-            'public_email' => $this->getPublicEmail(),
+            //Warning this will leak user emails to public as the api isn't secure
+            //'public_email' => $this->getPublicEmail(),
             'url' => $this->getURL(),
             'receive_email' => $this->getReceiveEmail(),
             'contract_signed' => $this->hasSignedContract()

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -947,7 +947,6 @@ class MyRadio_User extends ServiceAPI implements APICaller
         //If there's a space, split into first and last name
         $name = trim($name);
         $names = explode(' ', $name);
-        //Needs adapting to nname - TOBEFIXED
         if (isset($names[1])) {
             return self::$db->fetchAll(
                 'SELECT memberid, fname, nname, sname, eduroam, local_alias FROM member

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -47,6 +47,13 @@ class MyRadio_User extends ServiceAPI implements APICaller
      */
     private $fname;
 
+     /**
+     * Stores the User's nickname.
+     *
+     * @var string
+     */
+    private $nname;
+
     /**
      * Stores the User's last name.
      *
@@ -237,7 +244,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $this->memberid = (int) $memberid;
         //Get the base data
         $data = self::$db->fetchOne(
-            'SELECT fname, sname, college AS collegeid, l_college.descr AS college,
+            'SELECT fname, nname, sname, college AS collegeid, l_college.descr AS college,
             phone, email, receive_email::boolean::text, local_name, local_alias, eduroam,
             account_locked::boolean::text, last_login, joined, profile_photo, bio,
             auth_provider, require_password_change::boolean::text, contract_signed::boolean::text, gdpr_accepted::boolean::text, 
@@ -434,6 +441,18 @@ class MyRadio_User extends ServiceAPI implements APICaller
         return $this->fname;
     }
 
+     /**
+     * Returns the User's first name.
+     *
+     * @return string The User's first name
+     */
+    public function getNName()
+    {
+        return $this->nname;
+    }
+
+
+
     /**
      * Returns the User's surname.
      *
@@ -451,7 +470,12 @@ class MyRadio_User extends ServiceAPI implements APICaller
      */
     public function getName()
     {
-        return $this->fname.' '.$this->sname;
+        if (empty($this->nname)) {
+            return $this->fname.' '.$this->sname;
+        } else {
+            return $this->fname.' "'.$this->nname.'" '.$this->sname;
+        }
+        return $this->fname.' '.$this->nname.' '.$this->sname;
     }
 
     public function getLastLogin()
@@ -925,14 +949,14 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $names = explode(' ', $name);
         if (isset($names[1])) {
             return self::$db->fetchAll(
-                'SELECT memberid, fname, sname, eduroam, local_alias FROM member
+                'SELECT memberid, fname, nname, sname, eduroam, local_alias FROM member
                 WHERE fname ILIKE $1 || \'%\' AND sname ILIKE $2 || \'%\'
                 ORDER BY sname, fname LIMIT $3',
                 [$names[0], $names[1], $limit]
             );
         } else {
             return self::$db->fetchAll(
-                'SELECT memberid, fname, sname, eduroam, local_alias FROM member
+                'SELECT memberid, fname, nname, sname, eduroam, local_alias FROM member
                 WHERE fname ILIKE $1 || \'%\' OR sname ILIKE $1 || \'%\'
                 ORDER BY sname, fname LIMIT $2',
                 [$name, $limit]
@@ -1279,6 +1303,14 @@ class MyRadio_User extends ServiceAPI implements APICaller
             throw new MyRadioException('Oh come on, everybody has a name.', 400);
         }
         $this->setCommonParam('fname', $fname);
+
+        return $this;
+    }
+
+    public function setNName($nname)
+    {
+
+        $this->setCommonParam('nname', $nname);
 
         return $this;
     }
@@ -1663,6 +1695,17 @@ class MyRadio_User extends ServiceAPI implements APICaller
             )
             ->addField(
                 new MyRadioFormField(
+                    'nname',
+                    MyRadioFormField::TYPE_TEXT,
+                    [
+                    'required' => false,
+                    'label' => 'Nickname',
+                    'value' => $this->getNName(),
+                    ]
+                )
+            )
+            ->addField(
+                new MyRadioFormField(
                     'sname',
                     MyRadioFormField::TYPE_TEXT,
                     [
@@ -1967,11 +2010,12 @@ class MyRadio_User extends ServiceAPI implements APICaller
 
         //Actually create the member!
         $r = self::$db->fetchColumn(
-            'INSERT INTO public.member (fname, sname, college, phone,
+            'INSERT INTO public.member (fname, nname, sname, college, phone,
             email, receive_email, eduroam, require_password_change)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING memberid',
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING memberid',
             [
                 $params['fname'],
+                $params['nname'],
                 $params['sname'],
                 $params['collegeid'],
                 $params['phone'],
@@ -2060,6 +2104,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
      * Creates a new User, or activates a user, if it already exists.
      *
      * @param string $fname         The User's first name.
+     * @param string $nname         The User's nick name.
      * @param string $sname         The User's last name.
      * @param string $eduroam       The User's @york.ac.uk address.
      * @param int    $collegeid     The User's college.
@@ -2074,6 +2119,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
      */
     public static function createOrActivate(
         $fname,
+        $nname,
         $sname,
         $eduroam = null,
         $collegeid = null,
@@ -2093,6 +2139,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         } else {
             $data = [
                 'fname' => $fname,
+                'nname' => $nname,
                 'sname' => $sname,
                 'eduroam' => $eduroam,
                 'collegeid' => $collegeid,
@@ -2119,6 +2166,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
      */
     public static function createActivateAPI(
         $fname,
+        $nname,
         $sname,
         $captcha,
         $eduroam = null,
@@ -2210,6 +2258,16 @@ class MyRadio_User extends ServiceAPI implements APICaller
         )
         ->addField(
             new MyRadioFormField(
+                'nname',
+                MyRadioFormField::TYPE_TEXT,
+                [
+                    'required' => false,
+                    'label' => 'Nickname',
+                ]
+            )
+        )
+        ->addField(
+            new MyRadioFormField(
                 'sname',
                 MyRadioFormField::TYPE_TEXT,
                 [
@@ -2296,6 +2354,14 @@ class MyRadio_User extends ServiceAPI implements APICaller
                             ]
                         ),
                         new MyRadioFormField(
+                            'nname',
+                            MyRadioFormField::TYPE_TEXT,
+                            [
+                                'required' => false,
+                                'label' => 'Nickname',
+                            ]
+                        ),
+                        new MyRadioFormField(
                             'sname',
                             MyRadioFormField::TYPE_TEXT,
                             [
@@ -2347,6 +2413,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $data['bio'] = 'This user is hidden';
         $data['memberid'] = $this->getID();
         $data['fname'] = 'Hidden';
+        $data['nname'] = 'Hidden';
         $datap['sname'] = 'User';
         $data['public_email'] = '';
         $data['url'] = $this->getURL();
@@ -2402,6 +2469,7 @@ class MyRadio_User extends ServiceAPI implements APICaller
         $data = [
             'memberid' => $this->getID(),
             'fname' => $this->getFName(),
+            'nname' => $this->getNName(),
             'sname' => $this->getSName(),
             'public_email' => $this->getPublicEmail(),
             'url' => $this->getURL(),

--- a/src/Classes/ServiceAPI/Profile.php
+++ b/src/Classes/ServiceAPI/Profile.php
@@ -57,6 +57,11 @@ class Profile extends ServiceAPI
         return self::getMembersForYear(CoreUtils::getAcademicYear());
     }
 
+    function rem_inx ($str, $ind)
+    { 
+       return substr($str,0,$ind++). substr($str,$ind);
+    }
+
     /**
      * Returns an Array representation of the given year's URY Members.
      *
@@ -72,14 +77,22 @@ class Profile extends ServiceAPI
     {
         self::wakeup();
 
-        return self::$db->fetchAll(
-            'SELECT member.memberid, sname || \', \' || fname AS name, l_college.descr AS college, paid, email, eduroam
+        /* Adding nickname can cause issues if the nickname is null;
+        * If you work out a way to have a default value for null values in SQL,
+        * message me on slack @Ren Herring
+        */ 
+
+        $result = self::$db->fetchAll(
+            'SELECT member.memberid, CONCAT(fname, \', \' ,sname)  AS name,  fname || \' "\' || nname || \'" \' || sname AS nickname, l_college.descr AS college, paid, email, eduroam
             FROM member INNER JOIN (SELECT * FROM member_year WHERE year = $1) AS member_year
             ON ( member.memberid = member_year.memberid ), l_college
             WHERE member.college = l_college.collegeid
             ORDER BY sname ASC',
             [$year]
         );
+        
+
+        return $result;
     }
 
     /**
@@ -102,7 +115,7 @@ class Profile extends ServiceAPI
             self::wakeup();
             self::$currentOfficers = self::$db->fetchAll(
                 'SELECT team.team_name AS team, officer.officer_name AS officership,
-                        sname || \', \' || fname AS name, member.memberid
+                        sname || \', "\' || nname || \'", \' || fname AS name, member.memberid
                 FROM member, officer, member_officer, team
                 WHERE member_officer.memberid = member.memberid
                     AND officer.officerid = member_officer.officerid
@@ -136,7 +149,7 @@ class Profile extends ServiceAPI
             self::wakeup();
             self::$officers = self::$db->fetchAll(
                 'SELECT team.team_name AS team, officer.type, officer.officer_name AS officership,
-                    fname || \' \' || sname AS name, member.memberid, officer.officerid
+                    fname || \'"\' || nname || \'"\' || sname AS name, member.memberid, officer.officerid
                 FROM team
                 LEFT JOIN officer ON team.teamid = officer.teamid AND officer.status = \'c\'
                 LEFT JOIN member_officer ON officer.officerid = member_officer.officerid

--- a/src/Controllers/Profile/bulkAdd.php
+++ b/src/Controllers/Profile/bulkAdd.php
@@ -19,6 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             $user = MyRadio_User::createOrActivate(
                 $params['fname'],
+                $params['nname'],
                 $params['sname'],
                 $params['eduroam'],
                 $params['collegeid']

--- a/src/Controllers/Profile/edit.php
+++ b/src/Controllers/Profile/edit.php
@@ -22,6 +22,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = $user->getEditForm()->readValues();
 
     $user->setFName($data['fname'])
+        ->setNName($data['nname'])
         ->setSName($data['sname'])
         ->setCollegeID($data['collegeid'])
         ->setPhone($data['phone'])

--- a/src/Controllers/Profile/quickAdd.php
+++ b/src/Controllers/Profile/quickAdd.php
@@ -10,6 +10,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $params = MyRadio_User::getQuickAddForm()->readValues();
     $user = MyRadio_User::createOrActivate(
         $params['fname'],
+        $params['nname'],
         $params['sname'],
         $params['eduroam'],
         $params['collegeid'],

--- a/src/Controllers/Setup/user.php
+++ b/src/Controllers/Setup/user.php
@@ -12,6 +12,7 @@ $pass_error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_REQUEST['password'] === $_REQUEST['passwordchk']) {
     $params = [
         'fname' => $_REQUEST['first-name'],
+        'nname' => $_REQUEST['nick-name'],
         'sname' => $_REQUEST['last-name'],
         'email' => $_REQUEST['email'],
         'phone' => $_REQUEST['phone'],

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -13,7 +13,7 @@ use \MyRadio\MyRadio\MyRadioNullSession;
  * This number is incremented every time a database patch is released.
  * Patches are scripts in schema/patches.
  */
-define('MYRADIO_CURRENT_SCHEMA_VERSION', 18);
+define('MYRADIO_CURRENT_SCHEMA_VERSION', 19);
 
 /*
  * Turn on Error Reporting for the start. Once the Config object is loaded

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -59,7 +59,7 @@ var MyRadioForm = {
           },
           {
             displayKey: function (i) {
-              return i.fname + " " + i.sname;
+              return i.fname + i.nname + i.sname;
             },
             source: memberLookup.ttAdapter(),
             templates: {
@@ -76,7 +76,13 @@ var MyRadioForm = {
                 } else {
                   identity = "(#" + i.memberid + ")";
                 }
-                return $("<p>").text(i.fname + " " + i.sname + " " + identity);
+                if (i.nname != null) {
+                  return $("<p>").text(i.fname + ' "' + i.nname + '" ' + i.sname + " " + identity);
+                }
+                else {
+                  return $("<p>").text(i.fname + " " + i.sname + " " + identity);
+                }
+                
               }
             }
           })

--- a/src/Public/js/myradio.form.js
+++ b/src/Public/js/myradio.form.js
@@ -59,7 +59,12 @@ var MyRadioForm = {
           },
           {
             displayKey: function (i) {
-              return i.fname + i.nname + i.sname;
+              if (i.nname != null) {
+                return i.fname + ' "' + i.nname + '" ' + i.sname;
+              }
+              else{ 
+                return i.fname + ' ' + i.sname;
+              }
             },
             source: memberLookup.ttAdapter(),
             templates: {
@@ -89,6 +94,7 @@ var MyRadioForm = {
           .on(
             "typeahead:selected",
             function (e, obj) {
+              
               idField.val(obj.memberid);
             }
           );

--- a/src/Public/js/myradio.timeslot.js
+++ b/src/Public/js/myradio.timeslot.js
@@ -69,12 +69,24 @@ $("#timeslots").on(
                     check.attr("name", "signin[]")
                       .attr("id", "signin_"+data[row].user.memberid)
                       .attr("value", data[row].user.memberid);
-                    label.attr("for", "signin_"+data[row].user.memberid)
-                      .html(data[row].user.fname + " " + data[row].user.sname);
+                    if (empty(data[row].user.nname) != false) {
+                      label.attr("for", "signin_"+data[row].user.memberid)
+                        .html(data[row].user.fname + ' "' + data[row].user.nname  + '" ' + data[row].user.sname);
+                    }
+                    else {
+                      label.attr("for", "signin_"+data[row].user.memberid)
+                        .html(data[row].user.fname + " " + data[row].user.sname);
+                    }
                     if (data[row].signedby !== null) {
                       check.attr("checked", "checked")
                         .attr("disabled", "true");
-                      label.append(" (Signed in by "+data[row].signedby.fname + " "+data[row].signedby.sname + ")");
+                      if (empty(data[row].signedby.nname) != false ) {
+                        label.append(" (Signed in by "+data[row].signedby.fname + ' "' + data[row].signedby.nname + '" ' + data[row].signedby.sname + ")");  
+                      }
+                      else {
+                        label.append(" (Signed in by "+data[row].signedby.fname + " " + data[row].signedby.sname + ")");
+                      }
+                      
                     } else if (data[row].user.memberid == window.myradio.memberid) {
                       check.attr("checked", "checked");
                     }
@@ -86,12 +98,22 @@ $("#timeslots").on(
                   if ($("#guest-signins").is(":empty")) {
                     $("#guest-signins").append("Guest data has been added by:<br>");
                   }
-                  $("#guest-signins").append(
-                    $("<span>")
-                      .text(data[row].signedby.fname + " " + data[row].signedby.sname
-                      + " (" + moment.unix(data[row].time).fromNow() + ")")
-                      .append("<br>")
-                  );
+                  if (empty(data[row].signedby.nname) != false) {
+                    $("#guest-signins").append(
+                      $("<span>")
+                        .text(data[row].signedby.fname + ' "'  + data[row].signedby.nname + '" ' + data[row].signedby.sname
+                        + " (" + moment.unix(data[row].time).fromNow() + ")")
+                        .append("<br>")
+                    );
+                  }
+                  else {
+                    $("#guest-signins").append(
+                      $("<span>")
+                        .text(data[row].signedby.fname + " " + data[row].signedby.sname
+                        + " (" + moment.unix(data[row].time).fromNow() + ")")
+                        .append("<br>")
+                    );
+                  }
                 }
               }
               $("#signin-list").append(

--- a/src/Templates/Profile/user.twig
+++ b/src/Templates/Profile/user.twig
@@ -13,7 +13,7 @@
     </tr>
     <tr>
       <td><b>Name:</b></td>
-      <td>{{user.fname}} {{user.sname}}</td>
+      <td>{{user.fname}} {{user.nname}} {{user.sname}}</td>
       <td rowspan="15" style="vertical-align:top"><img src="{{user.photo}}" width="300"></td>
     </tr>
     {% if user.college is defined %}

--- a/src/Templates/Profile/user.twig
+++ b/src/Templates/Profile/user.twig
@@ -155,7 +155,7 @@
             <em>by <a href="{{train.awarded_by.url}}">{{train.awarded_by.value}}</a>
               {% if train.revoked_by %}
                 , revoked on {{train.revoked_time|date("j/n/Y")}} by
-                <a href="{{train.revoked_by.url}}">{{train.revoked_by.fname}} {{train.revoked_by.sname}}</a>
+                <a href="{{train.revoked_by.url}}"> {{train.revoked_by.fname}} {{train.revoked_by.sname}}</a>
               {% endif %}
             </em>
           </li>

--- a/src/Templates/Setup/user.twig
+++ b/src/Templates/Setup/user.twig
@@ -4,6 +4,10 @@
 <form action="?c=user" method="POST">
 <label for="first-name">First Name</label>
     <input type="text" name="first-name" id="first-name" required><br>
+    
+    <label for="nick-name">Nickname</label>
+    <input type="text" name="nick-name" id="nick-name"><br>
+
     <label for="last-name">Last Name</label>
     <input type="text" name="last-name" id="last-name" required><br>
     <br>

--- a/tests/api/ShowSpecCest.php
+++ b/tests/api/ShowSpecCest.php
@@ -7,6 +7,7 @@ class ShowSpecCest
 {
     public static $user = [
         "fname" => "Testy",
+        "nname" => "Test",
         "sname" => "McTestFace",
         "receive_email" => false
     ];


### PR DESCRIPTION
Additions:
Nicknames - called nnames
- Database new column character varying 255 (can be null) member.nname
- 19.sql patch to allow for upgrades (manual migration must be done)
- (this has already been completed on ury's version of myradio)

Rewording:
- In my investigations of trying to fix 2016 site and myradio connections. I stumbled upon a miscommunication that user profiles have the email listed as public obtainable. But isn't called that in the user profile editor.

-Other minor updates
adds comments on what to remove if you want to setup your own mini ury (this is needed as 2016 site expects a mixcloud item)

Thank you for reading this pr,
(sorry whoever has to review it)
Also sorry for the scuffed ness I am on a train
Ren

See pictures below of example changes as tested on my docker cloud

Example of 2016 site after changes:
![image](https://github.com/user-attachments/assets/2de3a919-7ea6-49b3-8165-c098542b5ac2)

**Example Myradio changes:**

**example name nickname changes:**


![image](https://github.com/user-attachments/assets/45e71b5f-0b91-44f1-bc50-45804b767470)

![image](https://github.com/user-attachments/assets/d6d0c036-9bb8-4864-b8fc-f1d6f847b1fa)

https://github.com/user-attachments/assets/971646c7-8a0a-41b3-aaf5-bcdf6f13b7a7

Public email changes:

![image](https://github.com/user-attachments/assets/7405d113-8a0a-4164-9ea1-08b40fc22805)




