### PR TITLE
Remove xdebug from prod dockerfile and point error log to stderr

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -9,13 +9,6 @@ RUN docker-php-ext-install pgsql pdo_pgsql gd ldap curl xsl zip
 RUN pecl install memcached && \
     echo extension=memcached.so >> /usr/local/etc/php/conf.d/memcached.ini
 
-RUN pecl install xdebug-3.3.1 && docker-php-ext-enable xdebug \
- && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20220829/xdebug.so"' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
- && echo 'xdebug.client_port=9003' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
- && echo 'xdebug.mode=develop,debug' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
- && echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
- && echo 'xdebug.client_host=localhost' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-
 RUN echo 'error_reporting=E_ALL' >> /usr/local/etc/php/conf.d/error-reporting.ini
 
 RUN echo "memory_limit=512M" >> /usr/local/etc/php/conf.d/uploads.ini
@@ -40,7 +33,8 @@ RUN a2dissite 000-default && a2ensite myradio && \
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN mkdir -p /var/www/myradio && chown -R www-data:www-data /var/www/myradio && \
-    mkdir -p /var/log/myradio && chown -R www-data:www-data /var/log/myradio
+    mkdir -p /var/log/myradio && chown -R www-data:www-data /var/log/myradio && \
+    ln -s /var/log/myradio/errors.log /dev/stderr
 
 WORKDIR /var/www/myradio
 COPY composer.* /var/www/myradio/


### PR DESCRIPTION
* No reason for debugging stuff to be in our production image (and it may reduce some logspam)
* Not 100% sure if this will work (will give it a try), but it might mean we get better logging