### PR TITLE
fix: workaround broken email sending

### DIFF
--- a/src/Classes/MyRadioEmail.php
+++ b/src/Classes/MyRadioEmail.php
@@ -163,7 +163,7 @@ class MyRadioEmail extends ServiceAPI
 
     private function getHeader()
     {
-        $headers = ['MIME-Version: 1.0', 'Content-Transfer-Encoding: quoted-printable'];
+        $headers = ['MIME-Version: 1.0', 'Content-Transfer-Encoding: 8bit'];
 
         if ($this->from !== null) {
             $headers[] = 'From: '.$this->from->getName().' <'.$this->from->getPublicEmail().'>';
@@ -222,7 +222,7 @@ class MyRadioEmail extends ServiceAPI
                     if (!mail(
                         $user->getName() . ' <' . $user->getEmail() . '>',
                         $u_subject,
-                        quoted_printable_encode($u_message),
+                        $u_message,
                         $this->getHeader()
                     )) {
                         continue;


### PR DESCRIPTION
This should fix email formatting until we get round to rewriting email sending .

Tested locally with mailhog and the broken formatting doesn't show up anymore