### PR TITLE
[WIP] Check for concurrent edits of showplans

### DIFF
--- a/schema/patches/19.sql
+++ b/schema/patches/19.sql
@@ -1,0 +1,9 @@
+BEGIN;
+ALTER TABLE schedule.show_season_timeslot
+  ADD COLUMN showplan_last_modified TIMESTAMPTZ DEFAULT NULL;
+
+UPDATE myradio.schema
+SET value = 14
+WHERE attr='version';
+
+COMMIT;

--- a/src/Controllers/root.php
+++ b/src/Controllers/root.php
@@ -13,7 +13,7 @@ use \MyRadio\MyRadio\MyRadioNullSession;
  * This number is incremented every time a database patch is released.
  * Patches are scripts in schema/patches.
  */
-define('MYRADIO_CURRENT_SCHEMA_VERSION', 18);
+define('MYRADIO_CURRENT_SCHEMA_VERSION', 19);
 
 /*
  * Turn on Error Reporting for the start. Once the Config object is loaded


### PR DESCRIPTION
Add a simple mechanism to check if two people are editing a showplan at the same time, by storing the time it was last modified.

Will go together with a WebStudio change that will, when opened, get the last modified time from the server, and then send it back on every updateShowPlan call. The server will only accept the change if the time still matches (guarded by a `SELECT FOR UPDATE`), otherwise WebStudio will force the user to reload.

This can be a bit annoying, but the alternative is showplan corruption. Perhaps we can make WebStudio periodically poll for new changes to make it less annoying.