### PR TITLE
Show booking availability in training form

### DIFF
--- a/src/Classes/Config.php
+++ b/src/Classes/Config.php
@@ -82,6 +82,13 @@ final class Config
     public static $schedule_url = '//ury.org.uk/schedule';
 
     /**
+     * The full URL for the off-air studio booking microservice site.
+     *
+     * @var string
+     */
+    public static $booking_url = '//booking.ury.org.uk/';
+
+    /**
      * The base URL of the radio home pages.
      *
      * @var string
@@ -780,6 +787,7 @@ EOT;
             'base_url' => self::$base_url,
             'rewrite_url' => self::$rewrite_url,
             'schedule_url' => self::$schedule_url,
+            'booking_url' => self::$booking_url,
             'website_url' => self::$website_url,
             'timezone' => self::$timezone,
             'default_module' => self::$default_module,

--- a/src/Templates/Training/createDemo.twig
+++ b/src/Templates/Training/createDemo.twig
@@ -5,5 +5,5 @@
 {% block stripecontent %}
 <p>All sessions will last one hour, take a maximum of two participants and happen in a free studio. You will be registered as the Trainer for this session.</p>
 {{ parent() }}
-<iframe src="{{ config.schedule_url }}" style="width:100%; height: 1500px"></iframe>
+<iframe src="{{ config.booking_url }}" style="width:100%; height: 1500px"></iframe>
 {% endblock %}


### PR DESCRIPTION
Replaces the schedule preview with the booking form from the booking microservice site. This URL is set in the `config.php`.

Resolves issue with https://github.com/orgs/UniversityRadioYork/projects/10/views/6?pane=issue&itemId=80365237&issue=UniversityRadioYork%7CMyRadio%7C1185  but does not close ticket 