### PR TITLE
Update podcast art size requirements

### DIFF
--- a/src/Classes/ServiceAPI/MyRadio_Podcast.php
+++ b/src/Classes/ServiceAPI/MyRadio_Podcast.php
@@ -363,7 +363,7 @@ class MyRadio_Podcast extends MyRadio_Metadata_Common
                 [
                     'label' => 'Upload New Cover Photo',
                     'explanation' => 'If you haven\'t specified an existing cover photo, upload one '
-                    . 'here - it should be square and at least 400x400 pixels.',
+                    . 'here - it should be square and at least 3000x3000 pixels.',
                     'required' => false,
                 ]
             )


### PR DESCRIPTION
iTunes has changed its requirements for uploading podcast images from RSS feeds. Docs offer a range of options but request largest size which is 3000x3000

> Size: Square; 3000 x 3000 pixels. If you’re submitting your show via RSS feed, Apple Podcasts accepts show cover artwork ranging from 1400 x 1400 to 3000 x 3000 pixels. The largest size is preferred.

[https://podcasters.apple.com/support/896-artwork-requirements#:~:text=Size%3A%20Square%3B%203000%20x%203000,to%203000%20x%203000%20pixels.](https://podcasters.apple.com/support/896-artwork-requirements#:~:text=Size%3A%20Square%3B%203000%20x%203000,to%203000%20x%203000%20pixels.)