### PR TITLE
bump github action from checkout v2 to v4

### DIFF
--- a/.github/workflows/dev-base-image.yml
+++ b/.github/workflows/dev-base-image.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.ref || 'master' }}
     - name: Set up QEMU


### PR DESCRIPTION
This pull request includes a small but important update to the GitHub Actions workflow configuration. The change updates the version of the `actions/checkout` action used in the `dev-base-image.yml` workflow file.

* [`.github/workflows/dev-base-image.yml`](diffhunk://#diff-def1fc33748510214ed876edda3cfe9c87e7ed6936bccd45861816674d4db8e4L29-R29): Updated `actions/checkout` from version `v2` to `v4` to ensure compatibility with the latest features and improvements.

![image](https://github.com/user-attachments/assets/97364294-844e-461a-8635-d6dcecd219a0)
