### PR TITLE
fix: several warnings from php8 migration

### DIFF
--- a/src/Classes/MyRadioError.php
+++ b/src/Classes/MyRadioError.php
@@ -58,7 +58,7 @@ class MyRadioError
      */
     public static function errorsToArray($errno, $errstr, $errfile, $errline)
     {
-        if ($errno === E_STRICT or error_reporting() === 0) {
+        if ($errno === E_STRICT or (error_reporting() & $errno) === 0) {
             return;
         }
         $error_name = self::getErrorName($errno);

--- a/src/Classes/ServiceAPI/MyRadio_Show.php
+++ b/src/Classes/ServiceAPI/MyRadio_Show.php
@@ -190,8 +190,9 @@ class MyRadio_Show extends MyRadio_Metadata_Common
         }
 
         //Get information about Seasons
-        $this->season_ids = json_decode($result['seasons']);
-        if ($this->season_ids === null) {
+        if ($result['seasons'] !== null) {
+            $this->season_ids = json_decode($result['seasons']);
+        } else {
             $this->season_ids = [];
         }
     }

--- a/src/Classes/ServiceAPI/MyRadio_User.php
+++ b/src/Classes/ServiceAPI/MyRadio_User.php
@@ -1778,15 +1778,19 @@ class MyRadio_User extends ServiceAPI implements APICaller
                                      .'even if you are subscribed to mailing lists.',
                 ]
             )
-        )
-        ->addField(
+        );
+        $uni_email = NULL;
+        if ($this->getUniAccount() !== NULL) {
+            $uni_email = str_replace('@'.Config::$eduroam_domain, '', $this->getUniAccount());
+        }
+        $form->addField(
             new MyRadioFormField(
                 'eduroam',
                 MyRadioFormField::TYPE_TEXT,
                 [
                     'required' => false,
                     'label' => 'University Email',
-                    'value' => str_replace('@'.Config::$eduroam_domain, '', $this->getUniAccount()),
+                    'value' => $uni_email,
                     'explanation' => '@'.Config::$eduroam_domain,
                 ]
             )


### PR DESCRIPTION
I am going to spend a couple of weeks fixing (or at least noting down) PHP warnings at the top of myradio pages, then i'll undraft this