### PR TITLE
fix(webcams): remove old webcam refresh logic from SIS

### DIFF
--- a/src/Public/js/sis.webcam.js
+++ b/src/Public/js/sis.webcam.js
@@ -45,10 +45,6 @@ var Webcam = function () {
 
             img.setAttribute("src", data["streams"][i]["liveurl"]);
 
-            setInterval(function (image, source) {
-              image.setAttribute("src", source + "?_=" + Date.now());
-            }, 5000, img, data["streams"][i]["liveurl"]);
-
             caption.innerHTML = data["streams"][i]["streamname"];
 
             figure.className = "webcam-stream-container";


### PR DESCRIPTION
Webcams now use mjpeg streams, so don't need the refresh interval